### PR TITLE
Allow businesses that do not track weights additional flexibility

### DIFF
--- a/app/models/calculator/active_shipping.rb
+++ b/app/models/calculator/active_shipping.rb
@@ -117,7 +117,7 @@ class Calculator::ActiveShipping < Calculator
   def packages(order)
     multiplier = Spree::ActiveShipping::Config[:unit_multiplier]
     weight = order.line_items.inject(0) do |weight, line_item|
-      weight + (line_item.variant.weight ? (line_item.quantity * line_item.variant.weight * multiplier) : 0)
+      weight + (line_item.variant.weight ? (line_item.quantity * line_item.variant.weight * multiplier) : Spree::ActiveShipping::Config[:default_weight])
     end
     package = Package.new(weight, [], :units => Spree::ActiveShipping::Config[:units].to_sym)
     [package]

--- a/lib/active_shipping_configuration.rb
+++ b/lib/active_shipping_configuration.rb
@@ -19,6 +19,7 @@ class ActiveShippingConfiguration < Configuration
 
   preference :units, :string, :default => "imperial"
   preference :unit_multiplier, :integer, :default => 16 # 16 oz./lb - assumes variant weights are in lbs
+  preference :default_weight, :integer, :default => 0 # 16 oz./lb - assumes variant weights are in lbs
 
   validates_presence_of :name
   validates_uniqueness_of :name


### PR DESCRIPTION
Not exactly what one would call an academic amendment, but certainly a practical feature.

Accounting for monthly shipping expenses and month-over-month tweaking of this single value can help those businesses break even. 

NOTE: Default value set that people who do not use this feature are unaffected.
