### PR TITLE
Update active_shipping dependency

### DIFF
--- a/spree_active_shipping.gemspec
+++ b/spree_active_shipping.gemspec
@@ -18,6 +18,6 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
 
   s.add_dependency('spree_core', '>= 0.30.1')
-  s.add_dependency('active_shipping', '0.9.10')
+  s.add_dependency('active_shipping', '0.9.5')
   s.add_dependency('activemerchant', '1.9.0')
 end


### PR DESCRIPTION
Updating the active_shipping dependency to 0.9.10 eliminates problems with USPS mucking up their API. 

At current, rate estimates from USPS are returning to me as $0.00. 
With updating to active_shipping 0.9.10 the rates appear as expected.

I suggest moving to a versioning dependency that will automatically follow changes in the patch version. 

Thanks
