### PR TITLE
Ensure user revises shipping address after bad state/zipcode combination

### DIFF
--- a/app/controllers/checkout_controller_decorator.rb
+++ b/app/controllers/checkout_controller_decorator.rb
@@ -21,8 +21,8 @@ CheckoutController.class_eval do
           bill_address.update_attribute(:zipcode, nil)
           bill_address.update_attribute(:state, nil)
         end
-          ship_address.update_attribute(:zipcode, nil)
-          ship_address.update_attribute(:state, nil)
+        ship_address.update_attribute(:zipcode, nil)
+        ship_address.update_attribute(:state, nil)
       end
       redirect_to checkout_state_path(:address)
     end


### PR DESCRIPTION
Tested on a sandbox Spree install with SpreeActiveShipping.  When an error is thrown by ActiveMerchant and rendered in flash to the user, they are redirected back to the address form to revise their input.  If the user simply proceeds with checkout, however, the incorrect address is not re-evaluated and persists on the order.

This fix removes the `:zipcode` and `:state` attributes on the Address record without triggering validations to force the user to input a correct address before they can proceed to the delivery step.

Steps to reproduce:
- Sandbox Spree install with SpreeActiveShipping
- Create a ShippingMethod in the admin interface that will trigger the `Calculator::ActiveShipping#retrieve_rates` call.
- Add an item to your cart and proceed with checkout
- Input an address with a bad State/Zipcode combination (e.g. zip => 82001 and state => Alabama)
- Proceed to delivery, get redirected back to address, and proceed again

This sequence will lead you to the delivery form despite the invalid address.
