### PR TITLE
Set Spree::ActiveShipping::Config before initializers run

### DIFF
--- a/lib/spree_active_shipping/engine.rb
+++ b/lib/spree_active_shipping/engine.rb
@@ -3,7 +3,7 @@ end
 module SpreeActiveShippingExtension
   class Engine < Rails::Engine
 
-    initializer "spree.active_shipping.preferences", :after => "spree.environment" do |app|
+    initializer "spree.active_shipping.preferences", :before => :load_config_initializers do |app|
       Spree::ActiveShipping::Config = Spree::ActiveShippingConfiguration.new
     end
 


### PR DESCRIPTION
Without this change, you get an uninitialized constant error in the initializer when trying to set the config settings.  This is with the latest spree v1.0.0.rc2.
