### PR TITLE
Added test-mode preference

### DIFF
--- a/app/models/spree/calculator/fedex/base.rb
+++ b/app/models/spree/calculator/fedex/base.rb
@@ -4,7 +4,8 @@ module Spree
       ActiveMerchant::Shipping::FedEx.new(:key => Spree::ActiveShipping::Config[:fedex_key],
                                           :password => Spree::ActiveShipping::Config[:fedex_password],
                                           :account => Spree::ActiveShipping::Config[:fedex_account],
-                                          :login => Spree::ActiveShipping::Config[:fedex_login])
+                                          :login => Spree::ActiveShipping::Config[:fedex_login],
+                                          :test => Spree::ActiveShipping::Config[:test_mode])
     end
   end
 end

--- a/app/models/spree/calculator/ups/base.rb
+++ b/app/models/spree/calculator/ups/base.rb
@@ -4,12 +4,14 @@ module Spree
       if Spree::ActiveShipping::Config[:shipper_number].nil?
         ActiveMerchant::Shipping::UPS.new(:login => Spree::ActiveShipping::Config[:ups_login],
                                           :password => Spree::ActiveShipping::Config[:ups_password],
-                                          :key => Spree::ActiveShipping::Config[:ups_key])
+                                          :key => Spree::ActiveShipping::Config[:ups_key],
+                                          :test => Spree::ActiveShipping::Config[:test_mode])
       else
         ActiveMerchant::Shipping::UPS.new(:login => Spree::ActiveShipping::Config[:ups_login],
                                           :password => Spree::ActiveShipping::Config[:ups_password],
                                           :key => Spree::ActiveShipping::Config[:ups_key],
-                                          :origin_account => Spree::ActiveShipping::Config[:shipper_number])
+                                          :origin_account => Spree::ActiveShipping::Config[:shipper_number],
+                                          :test => Spree::ActiveShipping::Config[:test_mode])
       end
     end
   end

--- a/app/models/spree/calculator/usps/base.rb
+++ b/app/models/spree/calculator/usps/base.rb
@@ -1,7 +1,8 @@
 module Spree
   class Calculator::Usps::Base < Calculator::ActiveShipping::Base
     def carrier
-      ActiveMerchant::Shipping::USPS.new(:login => Spree::ActiveShipping::Config[:usps_login])
+      ActiveMerchant::Shipping::USPS.new( :login => Spree::ActiveShipping::Config[:usps_login],
+                                          :test => Spree::ActiveShipping::Config[:test_mode])
     end
   end
 end

--- a/lib/spree/active_shipping_configuration.rb
+++ b/lib/spree/active_shipping_configuration.rb
@@ -21,4 +21,6 @@ class Spree::ActiveShippingConfiguration < Spree::Preferences::Configuration
   preference :unit_multiplier, :integer, :default => 16 # 16 oz./lb - assumes variant weights are in lbs
   preference :default_weight, :integer, :default => 0 # 16 oz./lb - assumes variant weights are in lbs
   preference :handling_fee, :integer
+  
+  preference :test_mode, :boolean, :default => false
 end


### PR DESCRIPTION
I couldn't find a way to use a carrier's test environment with this extension so I added a preference that allows you to select between test and production.  Defaults to false (production servers).

Set with:
Spree::ActiveShipping::Config[:test_mode] = true
