### PR TITLE
Explicitly nest Spree::Calculator::Fedex class structure to avoid warnings

### DIFF
--- a/app/models/spree/calculator/fedex/base.rb
+++ b/app/models/spree/calculator/fedex/base.rb
@@ -1,6 +1,6 @@
 module Spree
   class Calculator
-    class Fedex
+    module Fedex
       class Base < Calculator::ActiveShipping::Base
         def carrier
           ActiveMerchant::Shipping::FedEx.new(:key => Spree::ActiveShipping::Config[:fedex_key],

--- a/app/models/spree/calculator/fedex/express_saver.rb
+++ b/app/models/spree/calculator/fedex/express_saver.rb
@@ -1,6 +1,6 @@
 module Spree
   class Calculator
-    class Fedex
+    module Fedex
       class ExpressSaver < Calculator::Fedex::Base
         def self.description
           I18n.t("fedex.express_saver")

--- a/app/models/spree/calculator/fedex/first_overnight.rb
+++ b/app/models/spree/calculator/fedex/first_overnight.rb
@@ -1,6 +1,6 @@
 module Spree
   class Calculator
-    class Fedex
+    module Fedex
       class FirstOvernight < Calculator::Fedex::Base
         def self.description
           I18n.t("fedex.first_overnight")

--- a/app/models/spree/calculator/fedex/ground.rb
+++ b/app/models/spree/calculator/fedex/ground.rb
@@ -1,6 +1,6 @@
 module Spree
   class Calculator
-    class Fedex
+    module Fedex
       class Ground < Calculator::Fedex::Base
         def self.description
           I18n.t("fedex.ground")

--- a/app/models/spree/calculator/fedex/ground_home_delivery.rb
+++ b/app/models/spree/calculator/fedex/ground_home_delivery.rb
@@ -1,6 +1,6 @@
 module Spree
   class Calculator
-    class Fedex
+    module Fedex
       class GroundHomeDelivery < Calculator::Fedex::Base
         def self.description
           I18n.t("fedex.ground_home_delivery")

--- a/app/models/spree/calculator/fedex/international_economy.rb
+++ b/app/models/spree/calculator/fedex/international_economy.rb
@@ -1,6 +1,6 @@
 module Spree
   class Calculator
-    class Fedex
+    module Fedex
       class InternationalEconomy < Calculator::Fedex::Base
         def self.description
           I18n.t("fedex.intl_economy")

--- a/app/models/spree/calculator/fedex/international_economy_freight.rb
+++ b/app/models/spree/calculator/fedex/international_economy_freight.rb
@@ -1,6 +1,6 @@
 module Spree
   class Calculator
-    class Fedex
+    module Fedex
       class InternationalEconomyFreight < Calculator::Fedex::Base
         def self.description
           I18n.t("fedex.intl_economy_freight")

--- a/app/models/spree/calculator/fedex/international_first.rb
+++ b/app/models/spree/calculator/fedex/international_first.rb
@@ -1,6 +1,6 @@
 module Spree
   class Calculator
-    class Fedex
+    module Fedex
       class InternationalFirst < Calculator::Fedex::Base
         def self.description
           I18n.t("fedex.intl_first")

--- a/app/models/spree/calculator/fedex/international_ground.rb
+++ b/app/models/spree/calculator/fedex/international_ground.rb
@@ -1,6 +1,6 @@
 module Spree
   class Calculator
-    class Fedex
+    module Fedex
       class InternationalGround < Calculator::Fedex::Base
         def self.description
           I18n.t("fedex.intl_ground")

--- a/app/models/spree/calculator/fedex/international_priority.rb
+++ b/app/models/spree/calculator/fedex/international_priority.rb
@@ -1,6 +1,6 @@
 module Spree
   class Calculator
-    class Fedex
+    module Fedex
       class InternationalPriority < Calculator::Fedex::Base
         def self.description
           I18n.t("fedex.intl_priority")

--- a/app/models/spree/calculator/fedex/international_priority_freight.rb
+++ b/app/models/spree/calculator/fedex/international_priority_freight.rb
@@ -1,6 +1,6 @@
 module Spree
   class Calculator
-    class Fedex
+    module Fedex
       class InternationalPriorityFreight < Calculator::Fedex::Base
         def self.description
           I18n.t("fedex.intl_priority_freight")

--- a/app/models/spree/calculator/fedex/international_priority_saturday_delivery.rb
+++ b/app/models/spree/calculator/fedex/international_priority_saturday_delivery.rb
@@ -1,6 +1,6 @@
 module Spree
   class Calculator
-    class Fedex
+    module Fedex
       class InternationalPrioritySaturdayDelivery < Calculator::Fedex::Base
         def self.description
           I18n.t("fedex.intl_priority_saturday_delivery")

--- a/app/models/spree/calculator/fedex/one_day_freight.rb
+++ b/app/models/spree/calculator/fedex/one_day_freight.rb
@@ -1,6 +1,6 @@
 module Spree
   class Calculator
-    class Fedex
+    module Fedex
       class OneDayFreight < Calculator::Fedex::Base
         def self.description
           I18n.t("fedex.one_day_freight")

--- a/app/models/spree/calculator/fedex/one_day_freight_saturday_delivery.rb
+++ b/app/models/spree/calculator/fedex/one_day_freight_saturday_delivery.rb
@@ -1,6 +1,6 @@
 module Spree
   class Calculator
-    class Fedex
+    module Fedex
       class OneDayFreightSaturdayDelivery < Calculator::Fedex::Base
         def self.description
           I18n.t("fedex.one_day_freight_saturday_delivery")

--- a/app/models/spree/calculator/fedex/priority_overnight.rb
+++ b/app/models/spree/calculator/fedex/priority_overnight.rb
@@ -1,6 +1,6 @@
 module Spree
   class Calculator
-    class Fedex
+    module Fedex
       class PriorityOvernight < Calculator::Fedex::Base
         def self.description
           I18n.t("fedex.priority_overnight")

--- a/app/models/spree/calculator/fedex/priority_overnight_saturday_delivery.rb
+++ b/app/models/spree/calculator/fedex/priority_overnight_saturday_delivery.rb
@@ -1,6 +1,6 @@
 module Spree
   class Calculator
-    class Fedex
+    module Fedex
       class PriorityOvernightSaturdayDelivery < Calculator::Fedex::Base
         def self.description
           I18n.t("fedex.priority_overnight_saturday_delivery")

--- a/app/models/spree/calculator/fedex/saver.rb
+++ b/app/models/spree/calculator/fedex/saver.rb
@@ -1,6 +1,6 @@
 module Spree
   class Calculator
-    class Fedex
+    module Fedex
       class Saver < Calculator::Fedex::Base
         def self.description
           I18n.t("fedex.saver")

--- a/app/models/spree/calculator/fedex/standard_overnight.rb
+++ b/app/models/spree/calculator/fedex/standard_overnight.rb
@@ -1,6 +1,6 @@
 module Spree
   class Calculator
-    class Fedex
+    module Fedex
       class StandardOvernight < Calculator::Fedex::Base
         def self.description
           I18n.t("fedex.standard_overnight")

--- a/app/models/spree/calculator/fedex/three_day_freight.rb
+++ b/app/models/spree/calculator/fedex/three_day_freight.rb
@@ -1,6 +1,6 @@
 module Spree
   class Calculator
-    class Fedex
+    module Fedex
       class ThreeDayFreight < Calculator::Fedex::Base
         def self.description
           I18n.t("fedex.three_day_freight")

--- a/app/models/spree/calculator/fedex/three_day_freight_saturday_delivery.rb
+++ b/app/models/spree/calculator/fedex/three_day_freight_saturday_delivery.rb
@@ -1,6 +1,6 @@
 module Spree
   class Calculator
-    class Fedex
+    module Fedex
       class ThreeDayFreightSaturdayDelivery < Calculator::Fedex::Base
         def self.description
           I18n.t("fedex.three_day_freight_saturday_delivery")

--- a/app/models/spree/calculator/fedex/two_day.rb
+++ b/app/models/spree/calculator/fedex/two_day.rb
@@ -1,6 +1,6 @@
 module Spree
   class Calculator
-    class Fedex
+    module Fedex
       class TwoDay < Calculator::Fedex::Base
         def self.description
           I18n.t("fedex.two_day")

--- a/app/models/spree/calculator/fedex/two_day_freight.rb
+++ b/app/models/spree/calculator/fedex/two_day_freight.rb
@@ -1,6 +1,6 @@
 module Spree
   class Calculator
-    class Fedex
+    module Fedex
       class TwoDayFreight < Calculator::Fedex::Base
         def self.description
           I18n.t("fedex.two_day_freight")

--- a/app/models/spree/calculator/fedex/two_day_freight_saturday_delivery.rb
+++ b/app/models/spree/calculator/fedex/two_day_freight_saturday_delivery.rb
@@ -1,6 +1,6 @@
 module Spree
   class Calculator
-    class Fedex
+    module Fedex
       class TwoDayFreightSaturdayDelivery < Calculator::Fedex::Base
         def self.description
           I18n.t("fedex.two_day_freight_saturday_delivery")

--- a/app/models/spree/calculator/fedex/two_day_saturday_delivery.rb
+++ b/app/models/spree/calculator/fedex/two_day_saturday_delivery.rb
@@ -1,6 +1,6 @@
 module Spree
   class Calculator
-    class Fedex
+    module Fedex
       class TwoDaySaturdayDelivery < Calculator::Fedex::Base
         def self.description
           I18n.t("fedex.two_day_saturday_delivery")


### PR DESCRIPTION
See https://gist.github.com/2371661 for evidence of what I'm fixing.

This happened when I created a class called `class Fedex` and included it into the application. Spree was trying to use the wrong one because of insufficient specification. This solves the issue.
