### PR TITLE
Fix timings cache key

### DIFF
--- a/app/models/spree/calculator/active_shipping/base.rb
+++ b/app/models/spree/calculator/active_shipping/base.rb
@@ -58,7 +58,7 @@ module Spree
                                      :state => (addr.state ? addr.state.abbr : addr.state_name),
                                      :city => addr.city,
                                      :zip => addr.zipcode)
-          timings = Rails.cache.fetch(cache_key(line_items)+"-timings") do
+          timings = Rails.cache.fetch(cache_key(order)+"-timings") do
             timings = retrieve_timings(origin, destination, packages(order))
           end
           return nil if timings.nil? || !timings.is_a?(Hash) || timings.empty?


### PR DESCRIPTION
The timing method would always fail because it was sending the wrong object to to generate a [cache_key](https://github.com/spree/spree_active_shipping/blob/master/app/models/spree/calculator/active_shipping/base.rb#L132).
