### PR TITLE
Fixes ups shipper number merge

### DIFF
--- a/app/models/spree/calculator/ups/base.rb
+++ b/app/models/spree/calculator/ups/base.rb
@@ -13,7 +13,7 @@ module Spree
           }
 
           if shipper_number = Spree::ActiveShipping::Config[:shipper_number]
-            carrier_details.merge(:origin_account => shipper_number)
+            carrier_details.merge!(:origin_account => shipper_number)
           end
 
           ActiveMerchant::Shipping::UPS.new(carrier_details)


### PR DESCRIPTION
The shipper number is never being merged into the carrier details.  This fixes that (and enables things like negotiated rates)
