### PR TITLE
Rescue from shipping error in orders controllers.

### DIFF
--- a/app/controllers/spree/orders_controller_decorator.rb
+++ b/app/controllers/spree/orders_controller_decorator.rb
@@ -1,0 +1,11 @@
+# handle shipping errors gracefully during order update
+Spree::OrdersController.class_eval do
+
+  rescue_from Spree::ShippingError, :with => :handle_shipping_error
+
+  private
+    def handle_shipping_error(e)
+      flash[:error] = e.message
+      redirect_back_or_default(root_path)
+    end
+end


### PR DESCRIPTION
Shipping price may be calculated when adding products to order if user is logged & address is filled.

Think it might be better for users to redirect them to request.referrer but redirecting to referrer doesn't seems to be a really good practice.
