### PR TITLE
Add Product Package functionality

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ spec/dummy
 *.swp
 Gemfile.lock
 .rvmrc
+.DS_Store

--- a/app/controllers/spree/admin/product_packages_controller.rb
+++ b/app/controllers/spree/admin/product_packages_controller.rb
@@ -1,0 +1,18 @@
+module Spree
+  module Admin
+    class ProductPackagesController < ResourceController
+      belongs_to 'spree/product', :find_by => :permalink
+      before_filter :find_packages
+      before_filter :setup_package, :only => [:index]
+
+      private
+        def find_packages
+          @packages = @product.product_packages
+        end
+
+        def setup_package
+          @product.product_packages.build
+        end
+    end
+  end
+end

--- a/app/models/spree/line_item_decorator.rb
+++ b/app/models/spree/line_item_decorator.rb
@@ -1,0 +1,4 @@
+# Add product packages relation
+Spree::LineItem.class_eval do
+  has_many :product_packages, :through => :product
+end

--- a/app/models/spree/product_decorator.rb
+++ b/app/models/spree/product_decorator.rb
@@ -1,0 +1,7 @@
+# Add product packages relation
+Spree::Product.class_eval do
+  has_many :product_packages, :dependent => :destroy
+
+  attr_accessible :product_packages_attributes
+  accepts_nested_attributes_for :product_packages, :allow_destroy => true, :reject_if => lambda { |pp| pp[:weight].blank? or Integer(pp[:weight]) < 1 }
+end

--- a/app/models/spree/product_package.rb
+++ b/app/models/spree/product_package.rb
@@ -1,0 +1,9 @@
+module Spree
+  class ProductPackage < ActiveRecord::Base
+    belongs_to :product
+
+    validates :length, :width, :height, :weight, :numericality => { :only_integer => true, :message => I18n.t('validation.must_be_int'), :greater_than => 0 }
+
+    attr_accessible :length, :width, :height, :weight
+  end
+end

--- a/app/overrides/add_packages_tab.rb
+++ b/app/overrides/add_packages_tab.rb
@@ -1,0 +1,6 @@
+Deface::Override.new(:virtual_path => "spree/admin/shared/_product_tabs",
+                     :name => "add_product_packages_tab",
+                     :insert_bottom => "[data-hook='admin_product_tabs']",
+                     :text => "<li<%== ' class=\"active\"' if current == 'Product Packages' %>>
+                       <%= link_to t(:product_packages), admin_product_product_packages_url(@product) %>
+                     </li>")

--- a/app/views/spree/admin/product_packages/index.html.erb
+++ b/app/views/spree/admin/product_packages/index.html.erb
@@ -1,0 +1,50 @@
+<%= render :partial => 'spree/admin/shared/product_sub_menu' %>
+
+<%= render :partial => 'spree/admin/shared/product_tabs', :locals => { :current => 'Product Packages' } %>
+
+<%= render :partial => 'spree/shared/error_messages', :locals => { :target => @product } %>
+
+<%= form_for @product, :url => admin_product_url(@product), :method => :put do |f| %>
+  <table class="index">
+    <thead>
+      <tr data-hook="product_packages_header">
+        <th><%= t(:length) %></th>
+        <th><%= t(:width) %></th>
+        <th><%= t(:height) %></th>
+        <th><%= t(:weight) %></th>
+        <th><%= t(:action) %></th>
+      </tr>
+    </thead>
+    <tbody id="product_packages" data-hook>
+      <%= f.fields_for :product_packages do |pp_form| %>
+        <tr class="product_package fields"  data-hook="product_package">
+          <td class='length'>
+            <%= pp_form.text_field :length %>
+          </td>
+          <td class='width'>
+            <%= pp_form.text_field :width %>
+          </td>
+          <td class='height'>
+            <%= pp_form.text_field :height %>
+          </td>
+          <td class='weight'>
+            <%= pp_form.text_field :weight %>
+          </td>
+          <td class="actions">
+            <%= link_to_remove_fields t(:remove), pp_form %>
+          </td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+
+  <%= hidden_field_tag 'clear_product_packages', 'true' %>
+
+  <p class="add_product_packages" data-hook="add_product_packages">
+  <%= link_to_add_fields t(:add_product_packages), 'tbody#product_packages' %>
+  </p>
+  <div id="prototypes" data-hook></div>
+    <%= image_tag 'spinner.gif', :plugin => 'spree', :style => 'display:none;', :id => 'busy_indicator' %>
+    <br />
+  <%= render :partial => 'spree/admin/shared/edit_resource_links' %>
+<% end %>

--- a/config/db/migrate/20130107030221_create_product_packages.rb
+++ b/config/db/migrate/20130107030221_create_product_packages.rb
@@ -1,0 +1,12 @@
+class CreateProductPackages < ActiveRecord::Migration
+  def change
+    create_table :spree_product_packages do |t|
+      t.integer "product_id",                :null => false
+      t.integer "length",     :default => 0, :null => false
+      t.integer "width",      :default => 0, :null => false
+      t.integer "height",     :default => 0, :null => false
+      t.integer "weight",     :default => 0, :null => false
+      t.timestamps
+    end
+  end
+end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -58,3 +58,5 @@ en:
     parcel_surface: "Canada Post Parcel Surface"
     small_packets_surface: "Canada Post Small Packets Surface"
   shipping_error: "Shipping Error"
+  product_packages: "Product Packages"
+  add_product_packages: "Add Product Packages"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,9 @@
 Spree::Core::Engine.routes.draw do
   namespace :admin do
     resource :active_shipping_settings, :only => ['show', 'update', 'edit']
+
+    resources :products do
+      resources :product_packages
+    end
   end
 end

--- a/spec/models/active_shipping_calculator_spec.rb
+++ b/spec/models/active_shipping_calculator_spec.rb
@@ -7,8 +7,8 @@ module ActiveShipping
 
     let(:country) { mock_model Spree::Country, :iso => "US", :state => mock_model(Spree::State, :abbr => "MD") }
     let(:address) { mock_model Spree::Address, :country => country, :state => country.state, :city => "Chevy Chase", :zipcode => "20815" }
-    let(:line_item_1) { mock_model(Spree::LineItem, :variant_id => 1, :quantity => 2, :variant => mock_model(Spree::Variant, :weight => 10)) }
-    let(:line_item_2) { mock_model(Spree::LineItem, :variant_id => 2, :quantity => 1, :variant => mock_model(Spree::Variant, :weight => 5.25)) }
+    let(:line_item_1) { mock_model(Spree::LineItem, :variant_id => 1, :quantity => 2, :variant => mock_model(Spree::Variant, :weight => 10), :product_packages => []) }
+    let(:line_item_2) { mock_model(Spree::LineItem, :variant_id => 2, :quantity => 1, :variant => mock_model(Spree::Variant, :weight => 5.25), :product_packages => []) }
     let(:order) { mock_model Spree::Order, :number => "R12345", :ship_address => address, :line_items =>  [ line_item_1, line_item_2 ] }
 
     let(:carrier) { Spree::ActiveShipping::BogusCarrier.new }


### PR DESCRIPTION
Product Packages are a way for products that ship in their own packages to be defined properly for shipping estimates.  It is extremely useful for certain cases like a 200 lb product that ships in 5x 40lb boxes because 200lbs throws a UPS ship error.  This commit includes the ability to enter product packages through the admin interface.

The calculator now includes product packages in it's base calculation.  The user can now enter packages for a particular product and have those packages be used in the base freight calculation.  The calculator checks the products for over weight limit packages and will raise an error if the packages weigh too much.

Signed-off-by: Nathan Lowrie nate@finelineautomation.com
