### PR TITLE
shipper_number gets set to "", which (being a truthy value) results in "Missing/Invalid Shipper/ShipperNumber" error response from UPS

### DIFF
--- a/lib/spree/active_shipping/ups_override.rb
+++ b/lib/spree/active_shipping/ups_override.rb
@@ -88,7 +88,7 @@ module Spree
                  #                   * Shipment/RateInformation element
 
                  #SPREE OVERRIDE Negotiated Rates
-                 if (origin_account = @options[:origin_account] || options[:origin_account])
+                 if (origin_account = @options[:origin_account].presence || options[:origin_account].presence)
                    shipment << XmlNode.new("RateInformation") do |rate_information|
                      rate_information << XmlNode.new("NegotiatedRatesIndicator", '')
                    end
@@ -157,7 +157,7 @@ module Spree
               location_node << XmlNode.new('PhoneNumber', location.phone.gsub(/[^\d]/,'')) unless location.phone.blank?
               location_node << XmlNode.new('FaxNumber', location.fax.gsub(/[^\d]/,'')) unless location.fax.blank?
 
-              if name == 'Shipper' and (origin_account = @options[:origin_account] || options[:origin_account])
+              if name == 'Shipper' and (origin_account = @options[:origin_account].presence || options[:origin_account].presence)
                 location_node << XmlNode.new('ShipperNumber', origin_account)
               elsif name == 'ShipTo' and (destination_account = @options[:destination_account] || options[:destination_account])
                 location_node << XmlNode.new('ShipperAssignedIdentificationNumber', destination_account)


### PR DESCRIPTION
I've been using ActiveShipping with UPS in the past without problems until I upgraded to Spree 1.3. I checked my `active_shipping_wiredump.log` and confirmed that it has never included a `<ShipperNumber>` node in the request before. It was only _after_ upgrading to Spree 1.3 that it started including that node and we started seeing this error.

Even though this preference is defined to have a `nil` default:

``` ruby
    preference :shipper_number, :string, :default => nil
```

somehow `Spree::ActiveShipping::Config[:shipper_number]` ended up getting set to "". I suspect it was probably set to "" when I edited the Active Shipping settings in the backend using the new `/admin/active_shipping_settings` page, since that page submits all settings as strings to the controller.

When `Spree::ActiveShipping::Config[:shipper_number]` is "", an empty ShipperNumber node is added to the request, resulting in a "Missing/Invalid Shipper/ShipperNumber" error response from UPS.

The solution seems to be to either prevent this setting from ever being set to "" to begin with — or handling the "" case and treating the same as nil.

By adding `.presence`, we can have it treat a "" value as nil so that it will skip adding the `<ShipperNumber>` node node when shipper_number is "" instead of treating "" as a truthy value.
