### PR TITLE
Don't include shipping weights for items that are in other shipments, coming from other stock locations.

### DIFF
--- a/app/models/spree/calculator/shipping/active_shipping/base.rb
+++ b/app/models/spree/calculator/shipping/active_shipping/base.rb
@@ -41,7 +41,6 @@ module Spree
             if order_packages.empty?
               {}
             else
-              binding.pry
               retrieve_rates(origin, destination, order_packages)
             end
           end


### PR DESCRIPTION
Fixes #76

This patch fixes an issue where we were adding in weights for other shipments coming from other stock locations. I think this properly splits out the relevant items in the shipment. I'm not clear if this has broken anything in the calcs that look at max weights and multiple packages. From what I have learned, I don't think a lot of that code specific to multiple packages could have worked as is...

cc @LBRapid, @Radar, @BDQ, @huoxito
