### PR TITLE
Change the base.rb active_shipping calculator to only do rate calculations for the stock_location

### DIFF
--- a/app/models/spree/calculator/shipping/active_shipping/base.rb
+++ b/app/models/spree/calculator/shipping/active_shipping/base.rb
@@ -17,11 +17,9 @@ module Spree
         end
 
         def compute(object)
-          if object.is_a?(Spree::Shipment) || object.is_a?(Spree::Stock::Package)
-            order = object.order
-          else
-            return nil
-          end
+          return nil unless object.is_a?(Spree::Shipment) || object.is_a?(Spree::Stock::Package)
+
+          order = object.order
 
           if object.is_a?(Spree::Shipment)
             @stock_location_id = object.stock_location_id


### PR DESCRIPTION
Change the base.rb active_shipping calculator to only do rate calculations for the stock_location
that is represented by the passed in object. We are dealing with Spree::Shipment and Spree::Stock::Package
objects only.

In researching this issue, it seems we are passing a Spree::Shipment object whenever promotion_adjustments
is called when adding items to the cart and on checkout, we are passing the Spree::Stock::Package object.

The crux of the change is at line 160 where I am limiting calculations to the object.stock_location_id

Changes gets better as I sort this out..
