### PR TITLE
Fix calculator to use Package object as required in 2.0

### DIFF
--- a/app/models/spree/calculator/shipping/usps/first_class_mail_parcels.rb
+++ b/app/models/spree/calculator/shipping/usps/first_class_mail_parcels.rb
@@ -7,9 +7,9 @@ module Spree
           "USPS First-Class Mail Parcel"
         end
 
-        def available?(order)
+        def available?(package)
           multiplier = Spree::ActiveShipping::Config[:unit_multiplier]
-          weight = order.line_items.inject(0) do |weight, line_item|
+          weight = package.order.line_items.inject(0) do |weight, line_item|
             weight + (line_item.variant.weight ? (line_item.quantity * line_item.variant.weight * multiplier) : 0)
           end
           #if weight in ounces > 13, then First Class Mail is not available for the order


### PR DESCRIPTION
Fixes https://github.com/spree/spree_active_shipping/issues/82
