### PR TITLE
Allow Spree::Order object to be passed in

### DIFF
--- a/app/models/spree/calculator/shipping/active_shipping/base.rb
+++ b/app/models/spree/calculator/shipping/active_shipping/base.rb
@@ -17,9 +17,15 @@ module Spree
         end
 
         def compute(object)
-          return nil unless object.is_a?(Spree::Shipment) || object.is_a?(Spree::Stock::Package)
+          return nil unless object.is_a?(Spree::Shipment) ||
+                            object.is_a?(Spree::Stock::Package) ||
+                            object.is_a?(Spree::Order)
 
-          order = object.order
+          if object.is_a?(Spree::Order)
+            order = object
+          else
+            order = object.order
+          end
 
           if object.is_a?(Spree::Shipment)
             @stock_location_id = object.stock_location_id


### PR DESCRIPTION
Allow order object to be passed in. We have shipping_method.id which is required.
