### PR TITLE
Deal with reality that not all calculable objects have stock_locations.

### DIFF
--- a/app/models/spree/calculator/shipping/active_shipping/base.rb
+++ b/app/models/spree/calculator/shipping/active_shipping/base.rb
@@ -28,8 +28,10 @@ module Spree
           end
 
           if object.is_a?(Spree::Shipment)
+            return nil unless defined? object.stock_location_id
             @stock_location_id = object.stock_location_id
           else
+            return nil unless defined? object.stock_location
             @stock_location_id = object.stock_location.id
           end
 


### PR DESCRIPTION
Not completely sure this is the right solution. Seems we should not be sending calculables to shipping calculators without a stock_location.

What say you @Radar, @LBRapid, @BDQ

This is in response to https://github.com/spree/spree/issues/3381
