### PR TITLE
Replace the stock_location_id instance variable.

### DIFF
--- a/app/models/spree/calculator/shipping/active_shipping/base.rb
+++ b/app/models/spree/calculator/shipping/active_shipping/base.rb
@@ -18,6 +18,7 @@ module Spree
 
         def compute(package)
           order = package.order
+          @stock_location_id = package.stock_location.id
 
           origin= Location.new(:country => Spree::ActiveShipping::Config[:origin_country],
                                :city => Spree::ActiveShipping::Config[:origin_city],


### PR DESCRIPTION
Inadvertently removed by https://github.com/spree/spree_active_shipping/commit/00dd7a17d42d21d31df6ce00523a3b3eab2dce90
