### PR TITLE
Fix issue where shipping methods were not being registered

### DIFF
--- a/lib/spree_active_shipping/engine.rb
+++ b/lib/spree_active_shipping/engine.rb
@@ -28,6 +28,9 @@ module SpreeActiveShippingExtension
     config.to_prepare &method(:activate).to_proc
 
     initializer "spree_active_shipping.register.calculators" do |app|
+      Dir[File.join(File.dirname(__FILE__), "../../app/models/spree/calculator/**/*.rb")].sort.each do |c|
+        Rails.env.production? ? require(c) : load(c)
+      end
 
       app.config.spree.calculators.shipping_methods.concat(
         Spree::Calculator::Shipping::Fedex::Base.descendants +


### PR DESCRIPTION
The 'descendants' method will return an empty array if the subclass files are not loaded first.

I think this may have been accidentally removed in a previous commit: 1ad5706b6f
