### PR TITLE
usps api name changes fixes #103

### DIFF
--- a/app/models/spree/calculator/shipping/usps/base.rb
+++ b/app/models/spree/calculator/shipping/usps/base.rb
@@ -2,6 +2,41 @@ module Spree
   module Calculator::Shipping
     module Usps
       class Base < Spree::Calculator::Shipping::ActiveShipping::Base
+
+        def compute(package)
+          order = package.order
+
+          origin = Location.new(:country => Spree::ActiveShipping::Config[:origin_country],
+                               :city => Spree::ActiveShipping::Config[:origin_city],
+                               :state => Spree::ActiveShipping::Config[:origin_state],
+                               :zip => Spree::ActiveShipping::Config[:origin_zip])
+          addr = order.ship_address
+
+          destination = Location.new(:country => addr.country.iso,
+                                     :state => (addr.state ? addr.state.abbr : addr.state_name),
+                                     :city => addr.city,
+                                     :zip => addr.zipcode)
+
+          rates_result = Rails.cache.fetch(cache_key(order)) do
+            order_packages = packages(order)
+            if order_packages.empty?
+              {}
+            else
+              retrieve_rates(origin, destination, order_packages)
+            end
+          end
+
+          return nil if rates_result.kind_of?(Spree::ShippingError)
+          return nil if rates_result.empty?
+          rate = rates_result[self.class.service_code]
+
+          return nil unless rate
+          rate = rate.to_f + (Spree::ActiveShipping::Config[:handling_fee].to_f || 0.0)
+
+          # divide by 100 since active_shipping rates are expressed as cents
+          return rate/100.0
+        end
+
         def carrier
           carrier_details = {
             :login => Spree::ActiveShipping::Config[:usps_login],
@@ -9,6 +44,44 @@ module Spree
           }
 
           ActiveMerchant::Shipping::USPS.new(carrier_details)
+        end
+
+        private
+
+        def retrieve_rates(origin, destination, packages)
+          begin
+            response = carrier.find_rates(origin, destination, packages)
+            # turn this beastly array into a nice little hash
+            rates = response.rates.collect do |rate|
+              service_code = rate.service_code.to_i
+              # leaving this here, since there should be a way to pass
+              # lead times back to spree
+              #service_name = rate.service_name.encode("UTF-8")
+              [service_code, rate.price]
+            end
+            rate_hash = Hash[*rates.flatten]
+            return rate_hash
+          rescue ActiveMerchant::ActiveMerchantError => e
+
+            if [ActiveMerchant::ResponseError, ActiveMerchant::Shipping::ResponseError].include?(e.class) && e.response.is_a?(ActiveMerchant::Shipping::Response)
+              params = e.response.params
+              if params.has_key?("Response") && params["Response"].has_key?("Error") && params["Response"]["Error"].has_key?("ErrorDescription")
+                message = params["Response"]["Error"]["ErrorDescription"]
+              # Canada Post specific error message
+              elsif params.has_key?("eparcel") && params["eparcel"].has_key?("error") && params["eparcel"]["error"].has_key?("statusMessage")
+                message = e.response.params["eparcel"]["error"]["statusMessage"]
+              else
+                message = e.message
+              end
+            else
+              message = e.message
+            end
+
+            error = Spree::ShippingError.new("#{I18n.t(:shipping_error)}: #{message}")
+            Rails.cache.write @cache_key, error #write error to cache to prevent constant re-lookups
+            raise error
+          end
+
         end
 
         protected

--- a/app/models/spree/calculator/shipping/usps/express_mail.rb
+++ b/app/models/spree/calculator/shipping/usps/express_mail.rb
@@ -2,6 +2,10 @@ module Spree
   module Calculator::Shipping
     module Usps
       class ExpressMail < Spree::Calculator::Shipping::Usps::Base
+        def self.service_code
+          3 #Priority Mail Express {0}™
+        end
+
         def self.description
           I18n.t("usps.express_mail")
         end

--- a/app/models/spree/calculator/shipping/usps/express_mail_international.rb
+++ b/app/models/spree/calculator/shipping/usps/express_mail_international.rb
@@ -23,6 +23,10 @@ module Spree
           "UY"=>44, "UZ"=>66, "VU"=>55, "VA"=>66, "VE"=>66, "VN"=>66, "WS"=>44, "YE"=>66, "ZM"=>66, "ZW"=>44
         }
 
+        def self.service_code
+          1 #Priority Mail Express International™
+        end
+
         def self.description
           I18n.t("usps.express_mail_intl")
         end

--- a/app/models/spree/calculator/shipping/usps/first_class_mail_parcels.rb
+++ b/app/models/spree/calculator/shipping/usps/first_class_mail_parcels.rb
@@ -3,6 +3,10 @@ module Spree
     module Usps
       class FirstClassMailParcels < Spree::Calculator::Shipping::Usps::Base
 
+        def self.service_code
+          0 #First-Class Mail® Parcel
+        end
+
         def self.description
           "USPS First-Class Mail Parcel"
         end

--- a/app/models/spree/calculator/shipping/usps/media_mail.rb
+++ b/app/models/spree/calculator/shipping/usps/media_mail.rb
@@ -2,6 +2,10 @@ module Spree
   module Calculator::Shipping
     module Usps
       class MediaMail < Spree::Calculator::Shipping::Usps::Base
+        def self.service_code
+          6 #Media Mail®
+        end
+
         def self.description
           I18n.t("usps.media_mail")
         end

--- a/app/models/spree/calculator/shipping/usps/priority_mail.rb
+++ b/app/models/spree/calculator/shipping/usps/priority_mail.rb
@@ -2,6 +2,10 @@ module Spree
   module Calculator::Shipping
     module Usps
       class PriorityMail < Spree::Calculator::Shipping::Usps::Base
+        def self.service_code
+          1 #Priority Mail {0}™
+        end
+
         def self.description
           I18n.t("usps.priority_mail")
         end

--- a/app/models/spree/calculator/shipping/usps/priority_mail_flat_rate_envelope.rb
+++ b/app/models/spree/calculator/shipping/usps/priority_mail_flat_rate_envelope.rb
@@ -2,6 +2,10 @@ module Spree
   module Calculator::Shipping
     module Usps
       class PriorityMailFlatRateEnvelope < Spree::Calculator::Shipping::Usps::Base
+        def self.service_code
+          16 #Priority Mail {0}™ Flat Rate Envelope
+        end
+
         def self.description
           I18n.t("usps.priority_mail_flat_rate_envelope")
         end

--- a/app/models/spree/calculator/shipping/usps/priority_mail_international.rb
+++ b/app/models/spree/calculator/shipping/usps/priority_mail_international.rb
@@ -26,6 +26,10 @@ module Spree
           "AE"=>70, "UZ"=>70, "VN"=>70
         }
 
+        def self.service_code
+          2 #Priority Mail International®
+        end
+
         def self.description
           I18n.t("usps.priority_mail_international")
         end

--- a/app/models/spree/calculator/shipping/usps/priority_mail_international_large_flat_rate_box.rb
+++ b/app/models/spree/calculator/shipping/usps/priority_mail_international_large_flat_rate_box.rb
@@ -18,6 +18,10 @@ module Spree
           "VE", "VG", "VN", "VU", "WF", "WS", "YE", "ZA", "ZM", "ZW"
         ]
 
+        def self.service_code
+          11 #Priority Mail International® Large Flat Rate Box
+        end
+
         def self.description
           I18n.t("usps.priority_mail_international_large_flat_rate_box")
         end

--- a/app/models/spree/calculator/shipping/usps/priority_mail_international_medium_flat_rate_box.rb
+++ b/app/models/spree/calculator/shipping/usps/priority_mail_international_medium_flat_rate_box.rb
@@ -18,6 +18,10 @@ module Spree
           "VE", "VG", "VN", "VU", "WF", "WS", "YE", "ZA", "ZM", "ZW"
         ]
 
+        def self.service_code
+          9 #Priority Mail International® Medium Flat Rate Box
+        end
+
         def self.description
           I18n.t("usps.priority_mail_international_medium_flat_rate_box")
         end

--- a/app/models/spree/calculator/shipping/usps/priority_mail_international_small_flat_rate_box.rb
+++ b/app/models/spree/calculator/shipping/usps/priority_mail_international_small_flat_rate_box.rb
@@ -18,6 +18,10 @@ module Spree
           "UY", "UZ", "VA", "VC", "VE", "VG", "VN", "VU", "WF", "WS", "YE", "ZA", "ZM", "ZW"
         ]
 
+        def self.service_code
+          16 #Priority Mail International® Small Flat Rate Box**
+        end
+
         def self.description
           I18n.t("usps.priority_mail_international_small_flat_rate_box")
         end

--- a/app/models/spree/calculator/shipping/usps/priority_mail_large_flat_rate_box.rb
+++ b/app/models/spree/calculator/shipping/usps/priority_mail_large_flat_rate_box.rb
@@ -2,6 +2,10 @@ module Spree
   module Calculator::Shipping
     module Usps
       class PriorityMailLargeFlatRateBox < Spree::Calculator::Shipping::Usps::Base
+        def self.service_code
+          22 #Priority Mail {0}™ Large Flat Rate Box
+        end
+
         def self.description
           I18n.t("usps.priority_mail_large_flat_rate_box")
         end

--- a/app/models/spree/calculator/shipping/usps/priority_mail_medium_flat_rate_boxes.rb
+++ b/app/models/spree/calculator/shipping/usps/priority_mail_medium_flat_rate_boxes.rb
@@ -2,6 +2,10 @@ module Spree
   module Calculator::Shipping
     module Usps
       class PriorityMailMediumFlatRateBox < Spree::Calculator::Shipping::Usps::Base
+        def self.service_code
+          17 #Priority Mail {0}™ Medium Flat Rate Box
+        end
+
         def self.description
           I18n.t("usps.priority_mail_medium_flat_rate_box")
         end

--- a/app/models/spree/calculator/shipping/usps/priority_mail_small_flat_rate_box.rb
+++ b/app/models/spree/calculator/shipping/usps/priority_mail_small_flat_rate_box.rb
@@ -2,6 +2,10 @@ module Spree
   module Calculator::Shipping
     module Usps
       class PriorityMailSmallFlatRateBox < Spree::Calculator::Shipping::Usps::Base
+        def self.service_code
+          28 #Priority Mail {0}™ Small Flat Rate Box
+        end
+
         def self.description
           I18n.t("usps.priority_mail_small_flat_rate_box")
         end


### PR DESCRIPTION
moving from matching service names (desc) to checking for service codes
in order to achieve this it was necessary to override compute and
retrieve rates from Spree::Calculator::Shipping::ActiveShipping::Base on
Spree::Calculator::Shipping::ActiveShipping::Usps::Base
I added a service code paramter to all the usps classes and made sure
it was the correct id, please refer to this issue for further
explanation: https://github.com/spree/spree_active_shipping/issues/103
