### PR TITLE
Add controller specs, fix bad attributes in ProductPackagesController

### DIFF
--- a/app/controllers/spree/admin/product_packages_controller.rb
+++ b/app/controllers/spree/admin/product_packages_controller.rb
@@ -5,6 +5,11 @@ module Spree
       before_filter :find_packages
       before_filter :setup_package, :only => [:index]
 
+      protected
+        def permitted_resource_params
+          params.require(:product_package).permit(permitted_product_package_attributes)
+        end
+
       private
         def find_packages
           @packages = @product.product_packages
@@ -15,11 +20,7 @@ module Spree
         end
 
         def permitted_product_package_attributes
-          [:rating, :title, :review]
-        end
-
-        def permitted_resource_params
-          params.require(:product_package).permit(permitted_product_package_attributes)
+          [:length, :width, :height, :weight]
         end
     end
   end

--- a/app/models/spree/product_package.rb
+++ b/app/models/spree/product_package.rb
@@ -2,6 +2,9 @@ module Spree
   class ProductPackage < ActiveRecord::Base
     belongs_to :product
 
-    validates :length, :width, :height, :weight, :numericality => { :only_integer => true, :message => I18n.t('validation.must_be_int'), :greater_than => 0 }
+    validates :length, :width, :height, :weight,
+              :numericality => { :only_integer => true,
+                                 :message => Spree.t('validation.must_be_int'),
+                                 :greater_than => 0 }
   end
 end

--- a/spec/controllers/admin/active_shipping_settings_controller_spec.rb
+++ b/spec/controllers/admin/active_shipping_settings_controller_spec.rb
@@ -1,0 +1,54 @@
+require 'spec_helper'
+
+describe Spree::Admin::ActiveShippingSettingsController do
+  stub_authorization!
+
+  context '#show' do
+    it 'should assign a Spree::ActiveShippingConfiguration and render the view' do
+      spree_get :show
+      assigns(:config).should be_an_instance_of(Spree::ActiveShippingConfiguration)
+      response.should render_template('show')
+    end
+  end
+
+  context '#edit' do
+    it 'should assign a Spree::ActiveShippingConfiguration and render the view' do
+      spree_get :edit
+      assigns(:config).should be_an_instance_of(Spree::ActiveShippingConfiguration)
+      response.should render_template('edit')
+    end
+  end
+
+  context '#update' do
+    config = Spree::ActiveShippingConfiguration.new
+    config.preferences.each do |name, orig_val|
+      case config.preference_type(name)
+      when :integer
+        it "should allow us to set the value of #{name}" do
+          new_val = SecureRandom.random_number(100)
+          spree_post :update, name => new_val
+          Spree::ActiveShippingConfiguration.new.send("preferred_#{name}").should eq(new_val)
+          response.should redirect_to(spree.admin_active_shipping_settings_path)
+        end
+      when :string
+        it "should allow us to set the value of #{name}" do
+          new_val = SecureRandom.hex(5)
+          spree_post :update, name => new_val
+          Spree::ActiveShippingConfiguration.new.send("preferred_#{name}").should eq(new_val)
+          response.should redirect_to(spree.admin_active_shipping_settings_path)
+        end
+      when :boolean
+        it "should allow us to switch the value of #{name}" do
+          spree_post :update, name => !orig_val
+          Spree::ActiveShippingConfiguration.new.send("preferred_#{name}").should eq(!orig_val)
+          response.should redirect_to(spree.admin_active_shipping_settings_path)
+        end
+      end
+    end
+
+    it "doesn't product an error when passed an invalid parameter name" do
+      spree_post :update, 'not_real_parameter_name' => 'not_real'
+      response.should redirect_to(spree.admin_active_shipping_settings_path)
+    end
+  end
+end

--- a/spec/controllers/admin/product_packages_controller_spec.rb
+++ b/spec/controllers/admin/product_packages_controller_spec.rb
@@ -1,0 +1,36 @@
+require 'spec_helper'
+
+describe Spree::Admin::ProductPackagesController do
+  stub_authorization!
+
+  context '#index' do
+    let(:product) { create(:product) }
+
+    it 'should find ProductPackages for the product and render the view' do
+      spree_get :index, product_id: product.permalink
+      assigns(:product).should eq(product)
+      response.should be_ok
+      response.should render_template('index')
+    end
+  end
+
+  context '#update' do
+    let!(:product) { create(:product) }
+    let!(:product_package) { create(:product_package, product: product) }
+
+    it 'should allow us to update the ProductPackage attributes' do
+      new_length = SecureRandom.random_number(19) + 1
+      new_width = SecureRandom.random_number(19) + 1
+      new_height = SecureRandom.random_number(19) + 1
+      new_weight = SecureRandom.random_number(19) + 1
+      spree_post :update, product_id: product.permalink, id: product_package.id,
+                          product_package: { length: new_length, width: new_width, 
+                                             height: new_height, weight: new_weight }
+      product_package.reload
+      product_package.length.should eq(new_length)
+      product_package.width.should eq(new_width)
+      product_package.height.should eq(new_height)
+      product_package.weight.should eq(new_weight)
+    end
+  end
+end

--- a/spec/factories/product_package_factory.rb
+++ b/spec/factories/product_package_factory.rb
@@ -1,0 +1,9 @@
+FactoryGirl.define do
+  factory :product_package, class: Spree::ProductPackage do
+    length { SecureRandom.random_number(19) + 1 }
+    width { SecureRandom.random_number(19) + 1 }
+    height { SecureRandom.random_number(19) + 1 }
+    weight { SecureRandom.random_number(19) + 1 }
+    product
+  end 
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,6 +5,7 @@ require File.expand_path("../dummy/config/environment.rb",  __FILE__)
 
 require 'rspec/rails'
 require 'webmock/rspec'
+require 'factory_girl'
 
 # Run any available migration
 ActiveRecord::Migrator.migrate File.expand_path("../dummy/db/migrate/", __FILE__)
@@ -17,8 +18,16 @@ Dir["#{File.dirname(__FILE__)}/lib/**/*.rb"].each {|f| require f}
 
 # Requires factories defined in spree_core
 require 'spree/testing_support/factories'
+require 'spree/testing_support/controller_requests'
+require 'spree/testing_support/authorization_helpers'
+require 'spree/testing_support/url_helpers'
+
+Dir[File.join(File.dirname(__FILE__), "factories/*.rb")].each {|f| require f }
 
 RSpec.configure do |config|
+  config.include Spree::TestingSupport::ControllerRequests
+  config.include FactoryGirl::Syntax::Methods
+  config.include Spree::TestingSupport::UrlHelpers
   config.include WebFixtures
   # == Mock Framework
   #


### PR DESCRIPTION
In my earlier PR I botched the attributes in the ProductPackagesController.  This PR:
1. Corrects the erroneous attribute list
2. Adds a basic controller spec for Spree::Admin::ProductPackagesController to cover the issue, as well as a basic spec for index
3. Adds a basic controller spec for Spree::Admin::ActiveShippingSettingsController
4. Uses Spree.t for a lingering i18n reference.
