### PR TITLE
Adjust Travis CI config to allow Travis to run against PR branches

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,13 +2,6 @@ before_install: gem install bundler
 before_script:
   - "bundle exec rake test_app"
 script: "DISPLAY=:99.0 bundle exec rspec spec"
-notifications:
-  email:
-    - jdyer@spreecommerce.com
-    - ryan@spreecommerce.com
-branches:
-  only:
-    - master
 rvm:
   - 1.9.3
   - 2.0.0


### PR DESCRIPTION
Some changes to the .travis.yml:
1. Remove Travis restriction to master
2. Disable external email notifications for ryan@spreecommerce.com and jdyer@spreecommerce.com

With these changes in place 3rd party committers should be able to take advantage of Travis as part of their dev process, and catch any spec failures before submitting their PR.  Similarly, spec failures on PRs will generally be visible to repo owners in the PR itself.

Submitters should go to https://travis-ci.org and turn on Travis CI integration for any forked repos they're using for development.
