### PR TITLE
Add simplecov so we can optionally generate coverage reports

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ spec/dummy
 Gemfile.lock
 .rvmrc
 .DS_Store
+coverage

--- a/.simplecov
+++ b/.simplecov
@@ -1,0 +1,5 @@
+require 'simplecov'
+
+# .simplecov
+SimpleCov.start 'rails' do
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,6 @@
 # Configure Rails Environment
 ENV["RAILS_ENV"] = "test"
-
+require 'simplecov' if ENV['COVERAGE']
 require File.expand_path("../dummy/config/environment.rb",  __FILE__)
 
 require 'rspec/rails'

--- a/spree_active_shipping.gemspec
+++ b/spree_active_shipping.gemspec
@@ -21,4 +21,5 @@ Gem::Specification.new do |s|
   s.add_dependency('active_shipping', '~> 0.10.0')
   s.add_development_dependency 'pry'
   s.add_development_dependency 'webmock'
+  s.add_development_dependency 'simplecov'
 end


### PR DESCRIPTION
Simplecov reports will be generated for a spec run if COVERAGE is set as an environment variable.  For example:

```
COVERAGE=true bundle exec rake
```

This is consistent with spree/spree behavior.
