### PR TITLE
Defining :original for add_active_shipping_settings_tab

### DIFF
--- a/app/overrides/add_active_shipping_settings_tab.rb
+++ b/app/overrides/add_active_shipping_settings_tab.rb
@@ -1,4 +1,5 @@
 Deface::Override.new(:virtual_path => "spree/admin/shared/_configuration_menu",
                      :name => "add_active_shipping_settings_tab",
                      :insert_bottom => "[data-hook='admin_configurations_sidebar_menu'], #admin_configurations_sidebar_menu[data-hook]",
-                     :text => "<li<%== ' class=\"active\"' if controller.controller_name == 'theme_settings' %>><%= link_to \"Active Shipping\", admin_active_shipping_settings_path %></li>")
+                     :text => "<li<%== ' class=\"active\"' if controller.controller_name == 'theme_settings' %>><%= link_to \"Active Shipping\", admin_active_shipping_settings_path %></li>",
+                     :original => "191af30ee9446f6ed95654122a6180b37929eb9c")


### PR DESCRIPTION
responding to warning message:

```
No :original defined for 'add_active_shipping_settings_tab', you should change its definition to include:
 :original => '191af30ee9446f6ed95654122a6180b37929eb9c'
```
