### PR TITLE
rate calculations per package not by order

### DIFF
--- a/app/models/spree/calculator/shipping/active_shipping/base.rb
+++ b/app/models/spree/calculator/shipping/active_shipping/base.rb
@@ -25,26 +25,10 @@ module Spree
           order = package.order
           stock_location = package.stock_location
 
-          origin= Location.new(:country => stock_location.country.iso,
-                               :city => stock_location.city,
-                               :state => (stock_location.state ? stock_location.state.abbr : stock_location.state_name),
-                               :zip => stock_location.zipcode)
+          origin = build_location(stock_location)
+          destination = build_location(order.ship_address)
 
-          addr = order.ship_address
-
-          destination = Location.new(:country => addr.country.iso,
-                                     :state => (addr.state ? addr.state.abbr : addr.state_name),
-                                     :city => addr.city,
-                                     :zip => addr.zipcode)
-
-          rates_result = Rails.cache.fetch(cache_key(order, package.stock_location)) do
-            order_packages = packages(order)
-            if order_packages.empty?
-              {}
-            else
-              retrieve_rates(origin, destination, order_packages)
-            end
-          end
+          rates_result = retrieve_rates_from_cache(package, origin, destination)
 
           return nil if rates_result.kind_of?(Spree::ShippingError)
           return nil if rates_result.empty?
@@ -70,7 +54,7 @@ module Spree
                                      :state => (addr.state ? addr.state.abbr : addr.state_name),
                                      :city => addr.city,
                                      :zip => addr.zipcode)
-          timings_result = Rails.cache.fetch(cache_key(order)+"-timings") do
+          timings_result = Rails.cache.fetch(cache_key(package)+"-timings") do
             retrieve_timings(origin, destination, packages(order))
           end
           raise timings_result if timings_result.kind_of?(Spree::ShippingError)
@@ -86,9 +70,9 @@ module Spree
         end
 
         private
-        def retrieve_rates(origin, destination, packages)
+        def retrieve_rates(origin, destination, shipment_packages)
           begin
-            response = carrier.find_rates(origin, destination, packages)
+            response = carrier.find_rates(origin, destination, shipment_packages)
             # turn this beastly array into a nice little hash
             rates = response.rates.collect do |rate|
               service_name = rate.service_name.encode("UTF-8")
@@ -144,21 +128,17 @@ module Spree
           end
         end
 
-
-
-        private
-
-        def convert_order_to_weights_array(order)
+        def convert_package_to_weights_array(package)
           multiplier = Spree::ActiveShipping::Config[:unit_multiplier]
           default_weight = Spree::ActiveShipping::Config[:default_weight]
-          max_weight = get_max_weight(order)
+          max_weight = get_max_weight(package)
 
-          weights = order.line_items.map do |line_item|
-            item_weight = line_item.variant.weight.to_f
+          weights = package.contents.map do |content_item|
+            item_weight = content_item.variant.weight.to_f
             item_weight = default_weight if item_weight <= 0
             item_weight *= multiplier
 
-            quantity = line_item.quantity
+            quantity = content_item.quantity
             if max_weight <= 0
               item_weight * quantity
             elsif item_weight == 0
@@ -185,15 +165,19 @@ module Spree
           weights.flatten.compact.sort
         end
 
-        def convert_order_to_item_packages_array(order)
+        def convert_package_to_item_packages_array(package)
           multiplier = Spree::ActiveShipping::Config[:unit_multiplier]
-          max_weight = get_max_weight(order)
+          max_weight = get_max_weight(package)
           packages = []
 
-          order.line_items.each do |line_item|
-            line_item.product_packages.each do |product_package|
+          package.contents.each do |content_item|
+            variant  = content_item.variant
+            quantity = content_item.quantity
+            product  = variant.product
+
+            product.product_packages.each do |product_package|
               if product_package.weight.to_f <= max_weight or max_weight == 0
-                line_item.quantity.times do |idx|
+                quantity.times do
                   packages << [product_package.weight * multiplier, product_package.length, product_package.width, product_package.height]
                 end
               else
@@ -206,23 +190,23 @@ module Spree
         end
 
         # Generates an array of Package objects based on the quantities and weights of the variants in the line items
-        def packages(order)
+        def packages(package)
           units = Spree::ActiveShipping::Config[:units].to_sym
           packages = []
-          weights = convert_order_to_weights_array(order)
-          max_weight = get_max_weight(order)
-          item_specific_packages = convert_order_to_item_packages_array(order)
+          weights = convert_package_to_weights_array(package)
+          max_weight = get_max_weight(package)
+          item_specific_packages = convert_package_to_item_packages_array(package)
 
           if max_weight <= 0
             packages << Package.new(weights.sum, [], :units => units)
           else
             package_weight = 0
-            weights.each do |li_weight|
-              if package_weight + li_weight <= max_weight
-                package_weight += li_weight
+            weights.each do |content_weight|
+              if package_weight + content_weight <= max_weight
+                package_weight += content_weight
               else
                 packages << Package.new(package_weight, [], :units => units)
-                package_weight = li_weight
+                package_weight = content_weight
               end
             end
             packages << Package.new(package_weight, [], :units => units) if package_weight > 0
@@ -235,7 +219,8 @@ module Spree
           packages
         end
 
-        def get_max_weight(order)
+        def get_max_weight(package)
+          order = package.order
           max_weight = max_weight_for_country(order.ship_address.country)
           max_weight_per_package = Spree::ActiveShipping::Config[:max_weight_per_package] * Spree::ActiveShipping::Config[:unit_multiplier]
           if max_weight == 0 and max_weight_per_package > 0
@@ -247,11 +232,34 @@ module Spree
           max_weight
         end
 
-        def cache_key(order,stock_location = nil)
-          sl = stock_location.nil? ? "" : "#{stock_location.id}-"
-          addr = order.ship_address
-          line_items_hash = Digest::MD5.hexdigest(order.line_items.map {|li| li.variant_id.to_s + "_" + li.quantity.to_s }.join("|"))
-          @cache_key = "#{sl}#{carrier.name}-#{order.number}-#{addr.country.iso}-#{addr.state ? addr.state.abbr : addr.state_name}-#{addr.city}-#{addr.zipcode}-#{line_items_hash}-#{I18n.locale}".gsub(" ","")
+        def cache_key(package)
+          stock_location = package.stock_location.nil? ? "" : "#{package.stock_location.id}-"
+          order = package.order
+          ship_address = package.order.ship_address
+          contents_hash = Digest::MD5.hexdigest(package.contents.map {|content_item| content_item.variant.id.to_s + "_" + content_item.quantity.to_s }.join("|"))
+          @cache_key = "#{stock_location}#{carrier.name}-#{order.number}-#{ship_address.country.iso}-#{fetch_best_state_from_address(ship_address)}-#{ship_address.city}-#{ship_address.zipcode}-#{contents_hash}-#{I18n.locale}".gsub(" ","")
+        end
+
+        def fetch_best_state_from_address address
+          address.state ? address.state.abbr : address.state_name
+        end
+
+        def build_location address
+          Location.new(:country => address.country.iso,
+                       :state   => fetch_best_state_from_address(address),
+                       :city    => address.city,
+                       :zip     => address.zipcode)
+        end
+
+        def retrieve_rates_from_cache package, origin, destination
+          Rails.cache.fetch(cache_key(package)) do
+            shipment_packages = packages(package)
+            if shipment_packages.empty?
+              {}
+            else
+              retrieve_rates(origin, destination, shipment_packages)
+            end
+          end
         end
       end
     end

--- a/app/models/spree/calculator/shipping/usps/base.rb
+++ b/app/models/spree/calculator/shipping/usps/base.rb
@@ -3,30 +3,14 @@ module Spree
     module Usps
       class Base < Spree::Calculator::Shipping::ActiveShipping::Base
 
-        def compute(package)
+        def compute_package(package)
           order = package.order
           stock_location = package.stock_location
 
-          origin= Location.new(:country => stock_location.country.iso,
-                               :city => stock_location.city,
-                               :state => (stock_location.state ? stock_location.state.abbr : stock_location.state_name),
-                               :zip => stock_location.zipcode)
+          origin = build_location(stock_location)
+          destination = build_location(order.ship_address)
 
-          addr = order.ship_address
-
-          destination = Location.new(:country => addr.country.iso,
-                                     :state => (addr.state ? addr.state.abbr : addr.state_name),
-                                     :city => addr.city,
-                                     :zip => addr.zipcode)
-
-          rates_result = Rails.cache.fetch(cache_key(order)) do
-            order_packages = packages(order)
-            if order_packages.empty?
-              {}
-            else
-              retrieve_rates(origin, destination, order_packages)
-            end
-          end
+          rates_result = retrieve_rates_from_cache(package, origin, destination)
 
           return nil if rates_result.kind_of?(Spree::ShippingError)
           return nil if rates_result.empty?
@@ -50,15 +34,12 @@ module Spree
 
         private
 
-        def retrieve_rates(origin, destination, packages)
+        def retrieve_rates(origin, destination, shipment_packages)
           begin
-            response = carrier.find_rates(origin, destination, packages)
+            response = carrier.find_rates(origin, destination, shipment_packages)
             # turn this beastly array into a nice little hash
             rates = response.rates.collect do |rate|
               service_code = rate.service_code.to_i
-              # leaving this here, since there should be a way to pass
-              # lead times back to spree
-              #service_name = rate.service_name.encode("UTF-8")
               [service_code, rate.price]
             end
             rate_hash = Hash[*rates.flatten]

--- a/spec/models/weight_limits_spec.rb
+++ b/spec/models/weight_limits_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'pry'
 include ActiveMerchant::Shipping
 
 module ActiveShipping
@@ -9,43 +10,41 @@ module ActiveShipping
     let(:usa) { FactoryGirl.create(:country, :name => "USA", :iso => "US") }
     let(:state) { FactoryGirl.create(:state, country: usa, abbr: 'MD', name: 'Maryland')}
     let(:us_address) { FactoryGirl.create(:address, :country => usa, :state => state, :city => "Chevy Chase", :zipcode => "20815") }
-    let(:line_item_1) { mock_model(Spree::LineItem, :variant_id => 1, :quantity => 10, :variant => mock_model(Spree::Variant, :weight => 20.0), :product_packages => []) }
-    let(:line_item_2) { mock_model(Spree::LineItem, :variant_id => 2, :quantity => 4, :variant => mock_model(Spree::Variant, :weight => 5.25), :product_packages => []) }
-    let(:line_item_3) { mock_model(Spree::LineItem, :variant_id => 3, :quantity => 1, :variant => mock_model(Spree::Variant, :weight => 29.0), :product_packages => []) }
-    let(:line_item_4) { mock_model(Spree::LineItem, :variant_id => 4, :quantity => 1, :variant => mock_model(Spree::Variant, :weight => 100.0), :product_packages => []) }
-    let(:line_item_5) { mock_model(Spree::LineItem, :variant_id => 5, :quantity => 1, :variant => mock_model(Spree::Variant, :weight => 0.0), :product_packages => []) }
-    let(:line_item_6) { mock_model(Spree::LineItem, :variant_id => 5, :quantity => 1, :variant => mock_model(Spree::Variant, :weight => -1.0), :product_packages => []) }
-    let(:package_1) { mock_model(Spree::ProductPackage, :length => 12, :width => 24, :height => 47, :weight => 36) }
-    let(:package_2) { mock_model(Spree::ProductPackage, :length => 6, :width => 6, :height => 51, :weight => 43) }
-    let(:line_item_7) { mock_model(Spree::LineItem, :variant_id => 3, :quantity => 2, :variant => mock_model(Spree::Variant, :weight => 29.0), :product_packages => [ package_1, package_2 ]) }
-    let(:order) { mock_model Spree::Order, :number => "R12345", :ship_address => address, :line_items =>  [ line_item_1, line_item_2, line_item_3 ] }
-    let(:us_order) { mock_model Spree::Order, :number => "R12347", :ship_address => us_address, :line_items =>  [ line_item_1, line_item_2, line_item_3 ] }
-    let(:too_heavy_order) {
-      order = FactoryGirl.create(:order_with_line_items, :number => "R12349",
-                                 :ship_address => us_address, :line_items_count => 2)
-      order.line_items.first.tap do |line_item|
-        line_item.quantity = 2
-        line_item.variant.save
-        line_item.variant.weight = 29.0
-        line_item.variant.save
-        line_item.save
-        # product packages?
-      end
-      order.line_items.last.tap do |line_item|
-        line_item.quantity = 2
-        line_item.variant.save
-        line_item.variant.weight = 100.0
-        line_item.variant.save
-        line_item.save
-        # product packages?
-      end
-      order
-    }
-
-    let(:order_with_invalid_weights) { mock_model Spree::Order, :number => "R12350", :ship_address => us_address, :line_items =>  [ line_item_5, line_item_6 ] }
-    let(:order_with_packages) { mock_model Spree::Order, :number => "R12345", :ship_address => address, :line_items =>  [ line_item_2, line_item_7 ] }
-
-
+    let(:package1) { mock_model(Spree::ProductPackage, :length => 12, :width => 24, :height => 47, :weight => 36) }
+    let(:package2) { mock_model(Spree::ProductPackage, :length => 6, :width => 6, :height => 51, :weight => 43) }
+    let(:variant1) { build(:variant, :weight => 20.0) }
+    let(:variant2) { build(:variant, :weight => 5.25) }
+    let(:variant3) { build(:variant, :weight => 29.0) }
+    let(:variant4) { build(:variant, :weight => 100.0) }
+    let(:variant5) { build(:variant, :weight => 0) }
+    let(:variant6) { build(:variant, :weight => -1.0) }
+    let(:variant7) { double(Spree::Variant, :weight => 29.0, :product => mock_model(Spree::Product, :product_packages => [package1, package2])) }
+    let(:variant8) { double(Spree::Variant, :weight => 5.25, :product => mock_model(Spree::Product, :product_packages => [])) }
+    let(:california) { FactoryGirl.create(:state, country: usa, abbr: 'CA', name: 'California') }
+    let(:stock_location) { FactoryGirl.create(:stock_location, :address1 => '1313 S Harbor Blvd', :address2 => '', :city => 'Anaheim', :state => california, :country => usa, :phone => '7147814000', :active => 1) }
+    let(:package) { double(Spree::Stock::Package,
+          order: mock_model(Spree::Order, :ship_address => address),
+          contents: [Spree::Stock::Package::ContentItem.new(variant1, 10),
+                    Spree::Stock::Package::ContentItem.new(variant2, 4),
+                    Spree::Stock::Package::ContentItem.new(variant3, 1)]) }
+    let(:too_heavy_package) { double(Spree::Stock::Package,
+          order: mock_model(Spree::Order, :ship_address => us_address),
+          stock_location: stock_location,
+          contents: [Spree::Stock::Package::ContentItem.new(variant3, 2),
+                    Spree::Stock::Package::ContentItem.new(variant4, 2)]) }
+    let(:us_package) { double(Spree::Stock::Package,
+          order: mock_model(Spree::Order, :ship_address => us_address),
+          contents: [Spree::Stock::Package::ContentItem.new(variant1, 10),
+                    Spree::Stock::Package::ContentItem.new(variant2, 4),
+                    Spree::Stock::Package::ContentItem.new(variant3, 1)]) }
+    let(:package_with_invalid_weights) { double(Spree::Stock::Package,
+          order: mock_model(Spree::Order, :ship_address => us_address),
+          contents: [Spree::Stock::Package::ContentItem.new(variant5, 1),
+                    Spree::Stock::Package::ContentItem.new(variant6, 1)]) }
+    let(:package_with_packages) { double(Spree::Stock::Package,
+          order: mock_model(Spree::Order, :ship_address => us_address),
+          contents: [Spree::Stock::Package::ContentItem.new(variant8, 4),
+                    Spree::Stock::Package::ContentItem.new(variant7, 2)]) }
     let(:international_calculator) {  Spree::Calculator::Shipping::Usps::PriorityMailInternational.new }
     let(:domestic_calculator) {  Spree::Calculator::Shipping::Usps::PriorityMail.new }
 
@@ -58,21 +57,20 @@ module ActiveShipping
 
     describe "compute" do
       context "for international calculators" do
-        it "should convert order line items to weights array for non-US countries (ex. Canada [limit = 66 lbs])" do
-          weights = international_calculator.send :convert_order_to_weights_array, order
-          weights.should == [20.0, 21.0, 29.0, 60.0, 60.0, 60.0].map{|x| x*Spree::ActiveShipping::Config[:unit_multiplier]}
+        it "should convert package contents to weights array for non-US countries (ex. Canada [limit = 66lbs])" do
+          weights = international_calculator.send :convert_package_to_weights_array, package
+          weights.should == [20.0, 21.0, 29.0, 60.0, 60.0, 60.0].map{|x| x * Spree::ActiveShipping::Config[:unit_multiplier]}
         end
 
         it "should create array of packages" do
-          packages = international_calculator.send :packages, order
+          packages = international_calculator.send :packages, package
           packages.size.should == 5
-          packages.map{|package| package.weight.amount}.should == [41.0, 29.0, 60.0, 60.0, 60.0].map{|x| x*Spree::ActiveShipping::Config[:unit_multiplier]}
+          packages.map{|package| package.weight.amount}.should == [41.0, 29.0, 60.0, 60.0, 60.0].map{|x| x * Spree::ActiveShipping::Config[:unit_multiplier]}
           packages.map{|package| package.weight.unit}.uniq.should == [:ounces]
         end
 
         context "raise exception if max weight exceeded" do
           it "should get Spree::ShippingError" do
-            too_heavy_package = too_heavy_order.shipments.first.to_package
             expect { international_calculator.compute(too_heavy_package) }.to raise_error(Spree::ShippingError)
           end
         end
@@ -80,14 +78,14 @@ module ActiveShipping
 
       context "for domestic calculators" do
         it "should not convert order line items to weights array for US" do
-          weights = domestic_calculator.send :convert_order_to_weights_array, us_order
-          weights.should == [20.0, 21.0, 29.0, 60.0, 60.0, 60.0].map{|x| x*Spree::ActiveShipping::Config[:unit_multiplier]}
+          weights = domestic_calculator.send :convert_package_to_weights_array, us_package
+          weights.should == [20.0, 21.0, 29.0, 60.0, 60.0, 60.0].map{|x| x * Spree::ActiveShipping::Config[:unit_multiplier]}
         end
 
         it "should create array with one package for US" do
-          packages = domestic_calculator.send :packages, us_order
+          packages = domestic_calculator.send :packages, us_package
           packages.size.should == 4
-          packages.map{|package| package.weight.amount}.should == [70.0, 60.0, 60.0, 60.0].map{|x| x*Spree::ActiveShipping::Config[:unit_multiplier]}
+          packages.map{|package| package.weight.amount}.should == [70.0, 60.0, 60.0, 60.0].map{|x| x * Spree::ActiveShipping::Config[:unit_multiplier]}
           packages.map{|package| package.weight.unit}.uniq.should == [:ounces]
         end
       end
@@ -95,25 +93,25 @@ module ActiveShipping
 
     describe "weight limits" do
       it "should be set for USPS calculators" do
-        international_calculator.send(:max_weight_for_country, country).should == 66.0*Spree::ActiveShipping::Config[:unit_multiplier] # Canada
-        domestic_calculator.send(:max_weight_for_country, country).should == 70.0*Spree::ActiveShipping::Config[:unit_multiplier]
+        international_calculator.send(:max_weight_for_country, country).should == 66.0 * Spree::ActiveShipping::Config[:unit_multiplier] # Canada
+        domestic_calculator.send(:max_weight_for_country, country).should == 70.0 * Spree::ActiveShipping::Config[:unit_multiplier]
       end
 
       it "should respect the max weight per package" do
         Spree::ActiveShipping::Config.set(:max_weight_per_package => 30)
-        weights = international_calculator.send :convert_order_to_weights_array, order
-        weights.should == [20.0, 20.0, 20.0, 20.0, 20.0, 20.0, 20.0, 20.0, 20.0, 20.0, 21.0, 29.0].map{|x| x*Spree::ActiveShipping::Config[:unit_multiplier]}
+        weights = international_calculator.send :convert_package_to_weights_array, package
+        weights.should == [20.0, 20.0, 20.0, 20.0, 20.0, 20.0, 20.0, 20.0, 20.0, 20.0, 21.0, 29.0].map{|x| x * Spree::ActiveShipping::Config[:unit_multiplier]}
 
-        packages = international_calculator.send :packages, order
+        packages = international_calculator.send :packages, package
         packages.size.should == 12
-        packages.map{|package| package.weight.amount}.should == [20.0, 20.0, 20.0, 20.0, 20.0, 20.0, 20.0, 20.0, 20.0, 20.0, 21.0, 29.0].map{|x| x*Spree::ActiveShipping::Config[:unit_multiplier]}
+        packages.map{|package| package.weight.amount}.should == [20.0, 20.0, 20.0, 20.0, 20.0, 20.0, 20.0, 20.0, 20.0, 20.0, 21.0, 29.0].map{|x| x * Spree::ActiveShipping::Config[:unit_multiplier]}
         packages.map{|package| package.weight.unit}.uniq.should == [:ounces]
       end
     end
 
     describe "validation of line item weight" do
       it "should avoid zero weight or negative weight" do
-        weights = domestic_calculator.send :convert_order_to_weights_array, order_with_invalid_weights
+        weights = domestic_calculator.send :convert_package_to_weights_array, package_with_invalid_weights
         default_weight = Spree::ActiveShipping::Config[:default_weight] * Spree::ActiveShipping::Config[:unit_multiplier]
         weights.should == [default_weight, default_weight]
       end
@@ -122,16 +120,16 @@ module ActiveShipping
     describe "validation of default weight of zero" do
       it "should accept zero default weight" do
         Spree::ActiveShipping::Config.set(:default_weight => 0)
-        weights = domestic_calculator.send :convert_order_to_weights_array, order_with_invalid_weights
+        weights = domestic_calculator.send :convert_package_to_weights_array, package_with_invalid_weights
         weights.should == [0, 0]
       end
     end
 
     describe "adds item packages" do
       it "should add item packages to weight calculation" do
-        packages = domestic_calculator.send :packages, order_with_packages
+        packages = domestic_calculator.send :packages, package_with_packages
         packages.size.should == 6
-        packages.map{|package| package.weight.amount}.should == [21, 58, 36, 36, 43, 43].map{|x| x*Spree::ActiveShipping::Config[:unit_multiplier]}
+        packages.map{|package| package.weight.amount}.should == [21, 58, 36, 36, 43, 43].map{|x| x * Spree::ActiveShipping::Config[:unit_multiplier]}
         packages.map{|package| package.weight.unit}.uniq.should == [:ounces]
       end
     end


### PR DESCRIPTION
- refactored the code to get measurements from the package object and not by the order.line_items which causes miscalculation when shipping from multiple stock_locations
- added some helper functions as well to cleanup some of the code
- added some verbose changes to make the code more readable

fixes #76
