### PR TITLE
Fix for product packages delete link, translations, and adding icon

### DIFF
--- a/app/overrides/add_packages_tab.rb
+++ b/app/overrides/add_packages_tab.rb
@@ -2,5 +2,5 @@ Deface::Override.new(:virtual_path => "spree/admin/shared/_product_tabs",
                      :name => "add_product_packages_tab",
                      :insert_bottom => "[data-hook='admin_product_tabs']",
                      :text => "<li<%== ' class=\"active\"' if current == 'Product Packages' %>>
-                       <%= link_to Spree.t(:product_packages), admin_product_product_packages_url(@product) %>
+                       <%= link_to Spree.t(:product_packages), admin_product_product_packages_url(@product), :class => 'icon-barcode' %>
                      </li>")

--- a/app/views/spree/admin/product_packages/index.html.erb
+++ b/app/views/spree/admin/product_packages/index.html.erb
@@ -31,11 +31,7 @@
             <%= pp_form.text_field :weight %>
           </td>
           <td class="actions">
-            <% url = [:admin, @product, pp_form.object] %>
-            <%= link_to_with_icon('icon-trash', Spree.t(:remove), url,
-              :class => "remove_fields",
-              :data => {:action => 'remove'},
-              :title => Spree.t(:remove)) %>
+            <%= link_to_delete pp_form.object, { :url => [:admin, @product, pp_form.object], :no_text => true } %>
           </td>
         </tr>
       <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -58,5 +58,6 @@ en:
     parcel_surface: "Canada Post Parcel Surface"
     small_packets_surface: "Canada Post Small Packets Surface"
   shipping_error: "Shipping Error"
-  product_packages: "Product Packages"
-  add_product_packages: "Add Product Packages"
+  spree:
+    product_packages: "Product Packages"
+    add_product_packages: "Add Product Packages"


### PR DESCRIPTION
The delete action on product packages page was routing to show.

Steps to recreate are simple.
Add a product package to a product, and then click on the delete icon.

Also added an icon to the sidebar and fixed the translations
