### PR TITLE
Updated routes.rb to use :add_routes for 2.1

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,4 @@
-Spree::Core::Engine.routes.prepend do
+Spree::Core::Engine.add_routes do
   namespace :admin do
     resource :active_shipping_settings, :only => ['show', 'update', 'edit']
 


### PR DESCRIPTION
Verified, fixes failure to render under the admin configuration group.
