### PR TITLE
product packages have priority over dimensions

### DIFF
--- a/app/models/spree/calculator/shipping/active_shipping/base.rb
+++ b/app/models/spree/calculator/shipping/active_shipping/base.rb
@@ -155,6 +155,7 @@ module Spree
           max_weight = get_max_weight(package)
 
           weights = package.contents.map do |content_item|
+            next unless content_item.variant.product.product_packages.any? # product packages take priority over variant dimensions
             item_weight = content_item.variant.weight.to_f
             item_weight = default_weight if item_weight <= 0
             item_weight *= multiplier
@@ -211,6 +212,7 @@ module Spree
         end
 
         # Generates an array of Package objects based on the quantities and weights of the variants in the line items
+        # item specific packages have priority over variant dimensions
         def packages(package)
           units = Spree::ActiveShipping::Config[:units].to_sym
           packages = []


### PR DESCRIPTION
this is required so we don't send and extra package previously it would create a package with the default variant attributes and append it to the product packages, this would create **in some cases** expansive rate results

**in some cases:** carriers typically would measure the package and pick either the dimensions or the weight (whichever is more expensive) and use that to calculate the rates
