### PR TITLE
Fix an issue with product packages javascripts not precompiling properly

### DIFF
--- a/lib/spree_active_shipping/engine.rb
+++ b/lib/spree_active_shipping/engine.rb
@@ -39,6 +39,14 @@ module SpreeActiveShippingExtension
         Spree::Calculator::CanadaPost::Base.descendants
       )
     end
-  end
 
+        # sets the manifests / assets to be precompiled, even when initialize_on_precompile is false
+    initializer "spree.assets.precompile", :group => :all do |app|
+      app.config.assets.precompile += %w[
+        admin/product_packages/new.js
+        admin/product_packages/edit.js
+        admin/product_packages/index.js
+      ]
+    end
+  end
 end


### PR DESCRIPTION
Add the product package javascripts to the precompile list. Need this in order for the javascripts to be precompiled properly on production.
