### PR TITLE
wrapped a failing call to concat on empty string in lib/spree_active_shi...

### DIFF
--- a/lib/spree_active_shipping/engine.rb
+++ b/lib/spree_active_shipping/engine.rb
@@ -32,12 +32,14 @@ module SpreeActiveShippingExtension
         Rails.env.production? ? require(c) : load(c)
       end
 
-      app.config.spree.calculators.shipping_methods.concat(
-        Spree::Calculator::Shipping::Fedex::Base.descendants +
-        Spree::Calculator::Shipping::CanadaPost::Base.descendants +
-        Spree::Calculator::Shipping::Ups::Base.descendants +
-        Spree::Calculator::Shipping::Usps::Base.descendants
-      )
+      unless app.config.spree.calculators.shipping_methods.nil?
+        app.config.spree.calculators.shipping_methods.concat(
+          Spree::Calculator::Shipping::Fedex::Base.descendants +
+          Spree::Calculator::Shipping::CanadaPost::Base.descendants +
+          Spree::Calculator::Shipping::Ups::Base.descendants +
+          Spree::Calculator::Shipping::Usps::Base.descendants
+        )
+      end
     end
 
         # sets the manifests / assets to be precompiled, even when initialize_on_precompile is false


### PR DESCRIPTION
...pping/engine.rb, line 35. my system had no app.config.spree.calculators.shipping_methods.

Until I wrapped this call, I was unable to run migrations installed via railties, or boot Webrick. 

That commit message should actually read: "wrapped a failing call to concat on NIL in lib/spree_active_shipping/engine.rb, line 35. my system had no app.config.spree.calculators.shipping_methods." 

Sorry for the inaccuracy.
