### PR TITLE
Fix the USPS service descriptions to be more consistent

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -38,7 +38,7 @@ en:
   usps:
     express_mail: "USPS Express Mail"
     express_mail_intl: "USPS Express Mail International"
-    first_class_package_international: "First Class Package International Service"
+    first_class_package_international: "USPS First-Class Package International Service"
     media_mail: "USPS Media Mail"
     priority_mail: "USPS Priority Mail"
     priority_mail_small_flat_rate_box: "USPS Priority Mail Small Flat Rate Box"


### PR DESCRIPTION
This branch fixes the `usps.first_class_package_international` description to be more consistent with other usps descriptions, as well as matching the name returned by the API.
