### PR TITLE
Default value for shipping_methods (empty array) in lib/spree_active_shipping/engine.rb

### DIFF
--- a/lib/spree_active_shipping/engine.rb
+++ b/lib/spree_active_shipping/engine.rb
@@ -32,14 +32,13 @@ module SpreeActiveShippingExtension
         Rails.env.production? ? require(c) : load(c)
       end
 
-      unless app.config.spree.calculators.shipping_methods.nil?
-        app.config.spree.calculators.shipping_methods.concat(
-          Spree::Calculator::Shipping::Fedex::Base.descendants +
-          Spree::Calculator::Shipping::CanadaPost::Base.descendants +
-          Spree::Calculator::Shipping::Ups::Base.descendants +
-          Spree::Calculator::Shipping::Usps::Base.descendants
-        )
-      end 
+      app.config.spree.calculators.shipping_methods ||= []
+      app.config.spree.calculators.shipping_methods.concat(
+        Spree::Calculator::Shipping::Fedex::Base.descendants +
+        Spree::Calculator::Shipping::CanadaPost::Base.descendants +
+        Spree::Calculator::Shipping::Ups::Base.descendants +
+        Spree::Calculator::Shipping::Usps::Base.descendants
+      )
     end
 
         # sets the manifests / assets to be precompiled, even when initialize_on_precompile is false


### PR DESCRIPTION
I can't for the life of me figure out why my app.config.spree.calculators.shipping_methods don't exist at the time that your initializer runs (spree_active_shipping.register.calculators) but it doesn't. I set that to empty array just so that I can get my server to boot up, and added a block to my app's application.rb file like so:

``` ruby
config.after_initialize do 
      config.spree.calculators.shipping_methods.concat(
        Spree::Calculator::Shipping::Ups::Base.descendants
        #Spree::Calculator::Shipping::Fedex::Base.descendants +
        #Spree::Calculator::Shipping::CanadaPost::Base.descendants +
        #Spree::Calculator::Shipping::Usps::Base.descendants
      )    
end 
```

I'm only including UPS, per my client's negotiated rates deal, and preference to use only this carrier. 
Curious, anybody else is having similar issues?
