### PR TITLE
bumps active_shipping to sort fedex API changes

### DIFF
--- a/spree_active_shipping.gemspec
+++ b/spree_active_shipping.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
 
   s.add_dependency('spree_core', '~> 2.2.0.beta')
-  s.add_dependency('active_shipping', '~> 0.11.0')
+  s.add_dependency('active_shipping', '>= 0.11.2', '< 0.12')
   s.add_development_dependency 'pry'
   s.add_development_dependency 'webmock'
   s.add_development_dependency 'simplecov'


### PR DESCRIPTION
fixes #173

This locks our dependency on active_shipping on 0.11.2 since lower than this version would fail to parse the FedEx API response XML.

Fixes form active_shipping
FedEx API Parsing fixes:
https://github.com/Shopify/active_shipping/pull/135
FedEx API Request w/o state or province, fixes International FedEx rates (broken since FedEx API update this January)
https://github.com/Shopify/active_shipping/pull/141
