### PR TITLE
Fix error in example conversion from Kg to Oz.

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,10 +128,10 @@ It is important to note that by default this variable is set to have a value of 
 
 ### Example of converting from metric system to oz
 
-Say you have your weights in **kg** you would have to set the multiplier to **0.0283495**
+Say you have your weights in **kg** you would have to set the multiplier to **35.274**
 
 ```ruby
-Spree::ActiveShipping::Config[:unit_multiplier] = 0.0283495
+Spree::ActiveShipping::Config[:unit_multiplier] = 35.274
 ```
 
 Cache


### PR DESCRIPTION
The multiplier that converts from from Oz to Kg was given but we need to convert from Kg to Oz. The correct multiplier is 35.274.