### PR TITLE
Update Product Packages icon

### DIFF
--- a/app/overrides/spree/admin/shared/_product_tabs/add_product_packages_tab.html.erb.deface
+++ b/app/overrides/spree/admin/shared/_product_tabs/add_product_packages_tab.html.erb.deface
@@ -2,6 +2,6 @@
 
 <% if can? :update, @product.product_packages.build %>
   <li<%== ' class=\"active\"' if current == 'Product Packages' %>>
-     <%= link_to Spree.t(:product_packages), admin_product_product_packages_url(@product), class: 'fa fa-truck' %>
+    <%= link_to_with_icon 'cube', Spree.t(:product_packages), admin_product_product_packages_url(@product) %>
   </li>
 <% end %>


### PR DESCRIPTION
This takes advantage of the handy link_to_with_icon syntax sugar in Spree, and it swaps out the Truck icon (which is somewhat overloaded at the moment within Spree, also being used for Stock Movements and various other things) for a Cube icon that more closely resembles a product package.
