### PR TITLE
memoize service code prefix to prevent constant reassignment

### DIFF
--- a/app/models/spree/calculator/shipping/usps/base.rb
+++ b/app/models/spree/calculator/shipping/usps/base.rb
@@ -3,7 +3,7 @@ module Spree
     module Usps
       class Base < Spree::Calculator::Shipping::ActiveShipping::Base
 
-        SERVICE_CODE_PREFIX = {
+        SERVICE_CODE_PREFIX ||= {
           :international => 'intl',
           :domestic      => 'dom'
         }


### PR DESCRIPTION
While using spree active shipping, I was receiving this warning message from sidekiq:

```ruby
23:18:55 worker.1 | /Users/benmorgan/.rvm/gems/ruby-2.1.2/bundler/gems/spree_active_shipping-bdcb1360360b/app/models/spree/calculator/shipping/usps/base.rb:6: warning: already initialized constant Spree::Calculator::Shipping::Usps::Base::SERVICE_CODE_PREFIX
23:18:55 worker.1 | /Users/benmorgan/.rvm/gems/ruby-2.1.2/bundler/gems/spree_active_shipping-bdcb1360360b/app/models/spree/calculator/shipping/usps/base.rb:6: warning: previous definition of SERVICE_CODE_PREFIX was here
```

This PR contains a memoization onto the `SERVICE_CODE_PREFIX` to prevent reassignment when in a concurrent environment.

---

Also, Spree 2.4.0.rc2 is out. Time for a `2-4-stable` branch?