### PR TITLE
Bugfix - add the SpreeActiveShipping shipping methods *after* the core s...

### DIFF
--- a/lib/spree_active_shipping/engine.rb
+++ b/lib/spree_active_shipping/engine.rb
@@ -27,7 +27,7 @@ module SpreeActiveShippingExtension
     config.autoload_paths += %W(#{config.root}/lib)
     config.to_prepare &method(:activate).to_proc
 
-    initializer "spree_active_shipping.register.calculators" do |app|
+    initializer "spree_active_shipping.register.calculators", after: "spree.register.calculators" do |app|
       if app.config.spree.calculators.shipping_methods
         classes = Dir.chdir File.join(File.dirname(__FILE__), "../../app/models") do
           Dir["spree/calculator/**/*.rb"].reject {|path| path =~ /base.rb$/ }.map do |path|


### PR DESCRIPTION
...hipping methods are added

The engine initializer needs to add the SAS methods after SpreeCore has added the core shipping methods, otherwise the SAS shipping methods are not included.