### PR TITLE
Don't warn about double loading SERVICE_CODE_PREFIX if cache_classes is ...

### DIFF
--- a/lib/spree_active_shipping/engine.rb
+++ b/lib/spree_active_shipping/engine.rb
@@ -9,7 +9,7 @@ module SpreeActiveShippingExtension
 
     def self.activate
       Dir[File.join(File.dirname(__FILE__), "../../app/models/spree/calculator/**/base.rb")].sort.each do |c|
-        Rails.env.production? ? require(c) : load(c)
+        Rails.configuration.cache_classes ? require(c) : load(c)
       end
 
       Dir.glob(File.join(File.dirname(__FILE__), "../../app/**/*_decorator*.rb")) do |c|


### PR DESCRIPTION
This fixes #200 by using #require instead of #load if cache_classes is false.

The root of the problem is in engine.rb which is calling #constantize on the calculator classes on line 34. This triggers auto-loading of Spree::Calculator::Shipping::Usps::Base since express_mail.rb subclasses from it. This initializes the SERVICE_CODE_PREFIX constant the first time.

But then on line 12 of engine.rb the calculator base classes get loaded (unless we're running in production mode). This results in the base class being evaluated again and a warning being displayed (in dev or test mode) due to the SERVICE_CODE_PREFIX being initialized a second time.

Another way to fix this would be to use #require instead of #load regardless of the Rails environment being loaded, but I wasn't sure of the implications of doing that so I opted for a less dramatic change.