### PR TITLE
Rails 4.1.x in gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,7 @@ gem 'active_shipping', :github => "Shopify/active_shipping", :branch => 'master'
 
 group :development, :test do
   gem 'ffaker'
-  gem 'rails', '~> 4.0.5'
+  gem 'rails', '4.1.9'
   gem 'rspec-rails', '~> 2.13'
 end
 

--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ gem 'sqlite3'
 gem 'spree', :github => 'spree/spree', :branch => '2-3-stable'
 
 gem 'factory_girl_rails', '~> 4.2.1', :group => :test
-gem 'active_shipping', :github => "Shopify/active_shipping", :branch => 'master'
+gem 'active_shipping', '~> 0.12.5'
 
 group :development, :test do
   gem 'ffaker'


### PR DESCRIPTION
spree_active_shipping in `2-3-stable` is linked to Spree 2.3, which requires Rails 4.1.x. This updates from the Rails 4.0.x dependency in Spree 2.2 and earlier.