### PR TITLE
Added placeholder method `convert_package_to_dimensions_array`.

### DIFF
--- a/app/models/spree/calculator/shipping/active_shipping/base.rb
+++ b/app/models/spree/calculator/shipping/active_shipping/base.rb
@@ -213,27 +213,36 @@ module Spree
           packages
         end
 
+        # Used for calculating Dimensional Weight pricing.
+        # Override in your own extensions to compute package dimensions,
+        # or just leave this alone to keep the default behavior.
+        # Sample output: [9, 6, 3]
+        def convert_package_to_dimensions_array(package)
+          []
+        end
+
         # Generates an array of Package objects based on the quantities and weights of the variants in the line items
         def packages(package)
           units = Spree::ActiveShipping::Config[:units].to_sym
           packages = []
           weights = convert_package_to_weights_array(package)
           max_weight = get_max_weight(package)
+          dimensions = convert_package_to_dimensions_array(package)
           item_specific_packages = convert_package_to_item_packages_array(package)
 
           if max_weight <= 0
-            packages << Package.new(weights.sum, [], :units => units)
+            packages << Package.new(weights.sum, dimensions, :units => units)
           else
             package_weight = 0
             weights.each do |content_weight|
               if package_weight + content_weight <= max_weight
                 package_weight += content_weight
               else
-                packages << Package.new(package_weight, [], :units => units)
+                packages << Package.new(package_weight, dimensions, :units => units)
                 package_weight = content_weight
               end
             end
-            packages << Package.new(package_weight, [], :units => units) if package_weight > 0
+            packages << Package.new(package_weight, dimensions, :units => units) if package_weight > 0
           end
 
           item_specific_packages.each do |package|


### PR DESCRIPTION
Can be overridden in individual apps or extensions to calculate package dimensions for DIM weight pricing.

Addresses, but does not fix #199 