### PR TITLE
 ruby thinks 'ActiveShipping::FedEx' is part of Spree::ActiveShipping…

### DIFF
--- a/app/models/spree/calculator/shipping/fedex/base.rb
+++ b/app/models/spree/calculator/shipping/fedex/base.rb
@@ -13,7 +13,7 @@ module Spree
             :test => Spree::ActiveShipping::Config[:test_mode]
           }
 
-          ActiveShipping::FedEx.new(carrier_details)
+          ::ActiveShipping::FedEx.new(carrier_details)
         end
       end
     end


### PR DESCRIPTION
… module

In 16 line ruby thinks 'ActiveShipping::FedEx' is part of Spree::ActiveShipping module, and isn't. 'ActiveShipping::FedEx' is a class of active_shipping gem.

view issue:  https://github.com/spree-contrib/spree_active_shipping/issues/219