### PR TITLE
Update to active_shipping 1.2.2

### DIFF
--- a/spree_active_shipping.gemspec
+++ b/spree_active_shipping.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
 
   s.add_dependency('spree_core', '~> 3.0.0.beta')
-  s.add_dependency('active_shipping', '~> 1.0.0.pre4')
+  s.add_dependency('active_shipping', '~> 1.2.2')
   s.add_development_dependency 'pry'
   s.add_development_dependency 'webmock'
   s.add_development_dependency 'sass-rails', '~> 4.0.2'


### PR DESCRIPTION
Fixes a problem with small USPS packages throwing an error due to incorrect implementation of the protocol.