### PR TITLE
Loosen spree_core version dependency

### DIFF
--- a/spree_active_shipping.gemspec
+++ b/spree_active_shipping.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
   s.require_paths = ["lib"]
 
-  s.add_dependency('spree_core', '~> 3.0.0.beta')
+  s.add_dependency('spree_core', '~> 3.0.0')
   s.add_dependency('active_shipping', '~> 1.2.2')
   s.add_development_dependency 'pry'
   s.add_development_dependency 'webmock'


### PR DESCRIPTION
This allows the gem to be updated to use the current 3-0-stable.