### PR TITLE
Add USPS commercial price options

### DIFF
--- a/app/controllers/spree/admin/active_shipping_settings_controller.rb
+++ b/app/controllers/spree/admin/active_shipping_settings_controller.rb
@@ -3,7 +3,7 @@ class Spree::Admin::ActiveShippingSettingsController < Spree::Admin::BaseControl
   def edit
     @preferences_UPS = [:ups_login, :ups_password, :ups_key, :shipper_number]
     @preferences_FedEx = [:fedex_login, :fedex_password, :fedex_account, :fedex_key]
-    @preferences_USPS = [:usps_login]
+    @preferences_USPS = [:usps_login, :usps_commercial_base, :usps_commercial_plus]
     @preferences_CanadaPost = [:canada_post_login]
     @preferences_GeneralSettings = [:units, :unit_multiplier, :default_weight, :handling_fee, 
       :max_weight_per_package, :test_mode]

--- a/app/models/spree/calculator/shipping/usps/base.rb
+++ b/app/models/spree/calculator/shipping/usps/base.rb
@@ -41,7 +41,7 @@ module Spree
 
         def retrieve_rates(origin, destination, shipment_packages)
           begin
-            response = carrier.find_rates(origin, destination, shipment_packages)
+            response = carrier.find_rates(origin, destination, shipment_packages, rate_options)
             # turn this beastly array into a nice little hash
             service_code_prefix_key = response.params.keys.first == 'IntlRateV2Response' ? :international : :domestic
             rates = response.rates.collect do |rate|
@@ -77,6 +77,16 @@ module Spree
         # weight limit in ounces or zero (if there is no limit)
         def max_weight_for_country(country)
           1120  # 70 lbs
+        end
+
+        def rate_options
+          if Spree::ActiveShipping::Config[:usps_commercial_plus]
+            { commercial_plus: true }
+          elsif Spree::ActiveShipping::Config[:usps_commercial_base]
+            { commercial_base: true }
+          else
+            {}
+          end
         end
       end
     end

--- a/lib/spree/active_shipping_configuration.rb
+++ b/lib/spree/active_shipping_configuration.rb
@@ -11,6 +11,8 @@ class Spree::ActiveShippingConfiguration < Spree::Preferences::Configuration
   preference :fedex_key, :string, :default => "authorization_key"
 
   preference :usps_login, :string, :default => "aunt_judy"
+  preference :usps_commercial_base, :boolean, :default => false
+  preference :usps_commercial_plus, :boolean, :default => false
 
   preference :canada_post_login, :string, :default => "canada_post_login"
 

--- a/spree_active_shipping.gemspec
+++ b/spree_active_shipping.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
 
   s.add_dependency('spree_core', '~> 3.1.0.beta')
-  s.add_dependency('active_shipping', '~> 1.2.2')
+  s.add_dependency('active_shipping', '~> 1.4.2')
   s.add_development_dependency 'pry'
   s.add_development_dependency 'webmock'
   s.add_development_dependency 'sass-rails', '~> 4.0.2'


### PR DESCRIPTION
Adds 2 checkboxes to /admin/active_shipping_settings/edit that enable USPS Commercial Base or Commercial Plus rate prices.

@jspizziri or @JDutil would you please have a look? I'd like to see a green light from one other contributor before I merge this into master and back port to 3-0-stable.