### PR TITLE
Rename ActiveMerchant errors to ActiveShipping

### DIFF
--- a/app/models/spree/calculator/shipping/active_shipping/base.rb
+++ b/app/models/spree/calculator/shipping/active_shipping/base.rb
@@ -104,9 +104,9 @@ module Spree
             end
             rate_hash = Hash[*rates.flatten]
             return rate_hash
-          rescue ActiveMerchant::ActiveMerchantError => e
+          rescue ::ActiveShipping::Error => e
 
-            if [ActiveMerchant::ResponseError, ActiveShipping::ResponseError].include?(e.class) && e.response.is_a?(ActiveShipping::Response)
+            if e.class == ::ActiveShipping::ResponseError && e.response.is_a?(ActiveShipping::Response)
               params = e.response.params
               if params.has_key?("Response") && params["Response"].has_key?("Error") && params["Response"]["Error"].has_key?("ErrorDescription")
                 message = params["Response"]["Error"]["ErrorDescription"]
@@ -134,8 +134,8 @@ module Spree
               response = carrier.find_time_in_transit(origin, destination, packages)
               return response
             end
-          rescue ActiveShipping::ResponseError => re
-            if re.response.is_a?(ActiveShipping::Response)
+          rescue ::ActiveShipping::ResponseError => re
+            if re.response.is_a?(::ActiveShipping::Response)
               params = re.response.params
               if params.has_key?("Response") && params["Response"].has_key?("Error") && params["Response"]["Error"].has_key?("ErrorDescription")
                 message = params["Response"]["Error"]["ErrorDescription"]

--- a/app/models/spree/calculator/shipping/usps/base.rb
+++ b/app/models/spree/calculator/shipping/usps/base.rb
@@ -50,9 +50,9 @@ module Spree
             end
             rate_hash = Hash[*rates.flatten]
             return rate_hash
-          rescue ActiveMerchant::ActiveMerchantError => e
+          rescue ::ActiveShipping::Error => e
 
-            if [::ActiveMerchant::ResponseError, ::ActiveShipping::ResponseError].include?(e.class) && e.response.is_a?(ActiveShipping::Response)
+            if e.class == ::ActiveShipping::ResponseError && e.response.is_a?(::ActiveShipping::Response)
               params = e.response.params
               if params.has_key?("Response") && params["Response"].has_key?("Error") && params["Response"]["Error"].has_key?("ErrorDescription")
                 message = params["Response"]["Error"]["ErrorDescription"]

--- a/spec/models/active_shipping_calculator_spec.rb
+++ b/spec/models/active_shipping_calculator_spec.rb
@@ -86,7 +86,7 @@ module ActiveShipping
 
       context "when there is an error retrieving the rates" do
         before do
-          expect(carrier).to receive(:find_rates).and_raise(ActiveMerchant::ActiveMerchantError)
+          expect(carrier).to receive(:find_rates).and_raise(ActiveShipping::ResponseError)
         end
 
         it "should return false" do


### PR DESCRIPTION
This commit renames the usage of ActiveMerchant::ActiveMerchantError to
ActiveShipping::Error since as of v1.0.0 Active shipping uses ActiveShipping
namespace.

Fixes #235