### PR TITLE
Canada Post: add calculators for shipping to USA

### DIFF
--- a/app/models/spree/calculator/shipping/canada_post/expedited_usa.rb
+++ b/app/models/spree/calculator/shipping/canada_post/expedited_usa.rb
@@ -1,0 +1,11 @@
+module Spree
+    module Calculator::Shipping
+        module CanadaPost
+            class ExpeditedUsa < Spree::Calculator::Shipping::CanadaPost::Base
+                def self.description
+                    I18n.t("canada_post.expedited_usa")
+                end
+            end
+        end
+    end
+end

--- a/app/models/spree/calculator/shipping/canada_post/expedited_usa.rb
+++ b/app/models/spree/calculator/shipping/canada_post/expedited_usa.rb
@@ -1,11 +1,11 @@
 module Spree
-    module Calculator::Shipping
-        module CanadaPost
-            class ExpeditedUsa < Spree::Calculator::Shipping::CanadaPost::Base
-                def self.description
-                    I18n.t("canada_post.expedited_usa")
-                end
-            end
+  module Calculator::Shipping
+    module CanadaPost
+      class ExpeditedUsa < Spree::Calculator::Shipping::CanadaPost::Base
+        def self.description
+          I18n.t("canada_post.expedited_usa")
         end
+      end
     end
+  end
 end

--- a/app/models/spree/calculator/shipping/canada_post/priority_worldwide_usa.rb
+++ b/app/models/spree/calculator/shipping/canada_post/priority_worldwide_usa.rb
@@ -1,0 +1,11 @@
+module Spree
+    module Calculator::Shipping
+        module CanadaPost
+            class PriorityWorldwideUsa < Spree::Calculator::Shipping::CanadaPost::Base
+                def self.description
+                    I18n.t("canada_post.priority_worldwide_usa")
+                end
+            end
+        end
+    end
+end

--- a/app/models/spree/calculator/shipping/canada_post/priority_worldwide_usa.rb
+++ b/app/models/spree/calculator/shipping/canada_post/priority_worldwide_usa.rb
@@ -1,11 +1,11 @@
 module Spree
-    module Calculator::Shipping
-        module CanadaPost
-            class PriorityWorldwideUsa < Spree::Calculator::Shipping::CanadaPost::Base
-                def self.description
-                    I18n.t("canada_post.priority_worldwide_usa")
-                end
-            end
+  module Calculator::Shipping
+    module CanadaPost
+      class PriorityWorldwideUsa < Spree::Calculator::Shipping::CanadaPost::Base
+        def self.description
+          I18n.t("canada_post.priority_worldwide_usa")
         end
+      end
     end
+  end
 end

--- a/app/models/spree/calculator/shipping/canada_post/tracked_packet_usa.rb
+++ b/app/models/spree/calculator/shipping/canada_post/tracked_packet_usa.rb
@@ -1,0 +1,11 @@
+module Spree
+    module Calculator::Shipping
+        module CanadaPost
+            class TrackedPacketUsa < Spree::Calculator::Shipping::CanadaPost::Base
+                def self.description
+                    I18n.t("canada_post.tracked_packet_usa")
+                end
+            end
+        end
+    end
+end

--- a/app/models/spree/calculator/shipping/canada_post/tracked_packet_usa.rb
+++ b/app/models/spree/calculator/shipping/canada_post/tracked_packet_usa.rb
@@ -1,11 +1,11 @@
 module Spree
-    module Calculator::Shipping
-        module CanadaPost
-            class TrackedPacketUsa < Spree::Calculator::Shipping::CanadaPost::Base
-                def self.description
-                    I18n.t("canada_post.tracked_packet_usa")
-                end
-            end
+  module Calculator::Shipping
+    module CanadaPost
+      class TrackedPacketUsa < Spree::Calculator::Shipping::CanadaPost::Base
+        def self.description
+          I18n.t("canada_post.tracked_packet_usa")
         end
+      end
     end
+  end
 end

--- a/app/models/spree/calculator/shipping/canada_post/xpresspost_usa.rb
+++ b/app/models/spree/calculator/shipping/canada_post/xpresspost_usa.rb
@@ -1,11 +1,11 @@
 module Spree
-    module Calculator::Shipping
-        module CanadaPost
-            class XpresspostUsa < Spree::Calculator::Shipping::CanadaPost::Base
-                def self.description
-                    I18n.t("canada_post.xpresspost_usa")
-                end
-            end
+  module Calculator::Shipping
+    module CanadaPost
+      class XpresspostUsa < Spree::Calculator::Shipping::CanadaPost::Base
+        def self.description
+          I18n.t("canada_post.xpresspost_usa")
         end
+      end
     end
+  end
 end

--- a/app/models/spree/calculator/shipping/canada_post/xpresspost_usa.rb
+++ b/app/models/spree/calculator/shipping/canada_post/xpresspost_usa.rb
@@ -1,0 +1,11 @@
+module Spree
+    module Calculator::Shipping
+        module CanadaPost
+            class XpresspostUsa < Spree::Calculator::Shipping::CanadaPost::Base
+                def self.description
+                    I18n.t("canada_post.xpresspost_usa")
+                end
+            end
+        end
+    end
+end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -63,6 +63,10 @@ en:
     small_packets_air: "Canada Post Small Packets Air"
     parcel_surface: "Canada Post Parcel Surface"
     small_packets_surface: "Canada Post Small Packets Surface"
+    expedited_usa: "Canada Post Expedited US Business"
+    priority_worldwide_usa: "Canada Post Priority Worldwide USA"
+    tracked_packet_usa: "Canada Post Tracked Packet - USA"
+    xpresspost_usa: "Canada Post Xpresspost USA"
   shipping_error: "Shipping Error"
   spree:
     product_packages: "Product Packages"

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -9,4 +9,8 @@ fr:
     small_packets_air: "Postes Canada Petits Colis - Air"
     parcel_surface: "Postes Canada Colis Postaux - Surface"
     small_packets_surface: "Postes Canada Petits Colis - Surface"
+    expedited_usa: "Postes Canada Colis accélérés Business"
+    priority_worldwide_usa: "Postes Canada Priorité Mondial é.U."
+    tracked_packet_usa: "Postes Canada Paquet repérable - é.U."
+    xpresspost_usa: "Postes Canada Xpresspost USA"
   shipping_error: "Erreur de livraison"


### PR DESCRIPTION
This PR adds calculators to make it possible to use Canada Posts services to ship from Canada to USA.