### PR TITLE
Upgrade master branch

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,13 +5,13 @@ gem 'sqlite3'
 # TODO: Add to gemspec once gem is released
 gem "spree", github: "spree/spree", branch: 'master'
 
-gem 'factory_girl_rails', '~> 4.5.0', :group => :test
+gem 'factory_girl_rails', '~> 4.5.0', group: :test
 
 group :development, :test do
   gem 'ffaker'
   gem 'rails', '~> 4.2.0'
-  gem 'rspec-rails', '~> 3.0'
-  gem 'rspec-activemodel-mocks', '1.0.0'
+  gem 'rspec-rails', '~> 3.4.0'
+  gem 'rspec-activemodel-mocks', '~> 1.0.2'
 end
 
 gemspec

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Installation
 We highly recommend using the stable branches of this gem. If you were using version 1.3, you can place this line inside your application's Gemfile:
 
 ```ruby
-gem 'spree_active_shipping', :git => "git://github.com/spree/spree_active_shipping", :branch => "1-3-stable"
+gem 'spree_active_shipping', git: "git://github.com/spree/spree_active_shipping", branch: "1-3-stable"
 ```
 
 To install the latest edge version of this extension, place this line inside your application's Gemfile:
@@ -22,13 +22,13 @@ To install the latest edge version of this extension, place this line inside you
 - To use the latest edge code in master branch:
 
 ```ruby
-gem 'spree_active_shipping', :git => "git://github.com/spree/spree_active_shipping"
+gem 'spree_active_shipping', git: "git://github.com/spree/spree_active_shipping"
 ```
 
 - To use a specific branch specified in the Versionfile for your version of Spree:
 
 ```ruby
-gem 'spree_active_shipping', :git => "git://github.com/spree/spree_active_shipping", :branch => '1-3-stable'
+gem 'spree_active_shipping', git: "git://github.com/spree/spree_active_shipping", branch: '1-3-stable'
 ```
 
 **2.** Install migrations and migrate database:

--- a/Rakefile
+++ b/Rakefile
@@ -6,7 +6,7 @@ require 'spree/testing_support/extension_rake'
 
 RSpec::Core::RakeTask.new
 
-task :default => [:spec]
+task default: [:spec]
 
 desc 'Generates a dummy app for testing'
 task :test_app do

--- a/Versionfile
+++ b/Versionfile
@@ -1,9 +1,9 @@
-"2.1.x"  => { :branch => 'master' }
-"2.0.x"  => { :branch => '2-0-stable' }
-"1.3.x"  => { :branch => '1-3-stable' }
-"1.2.x"  => { :branch => '1-2-stable' }
-"1.1.x"  => { :branch => '1-1-stable' }
-"0.70.x" => { :version => '1.1.0', :branch => '0-70-stable' }
-"0.60.x" => { :version => '1.0.3', :branch => '0-60-stable' }
-"0.50.x" => { :version => '1.0.3', :ref => 'c582a227417ddc55ed7011b3208d37113ce87f09' }
-"0.40.x" => { :version => '1.0.3', :ref => 'c582a227417ddc55ed7011b3208d37113ce87f09' }
+"2.1.x"  => { branch: 'master' }
+"2.0.x"  => { branch: '2-0-stable' }
+"1.3.x"  => { branch: '1-3-stable' }
+"1.2.x"  => { branch: '1-2-stable' }
+"1.1.x"  => { branch: '1-1-stable' }
+"0.70.x" => { version: '1.1.0', branch: '0-70-stable' }
+"0.60.x" => { version: '1.0.3', branch: '0-60-stable' }
+"0.50.x" => { version: '1.0.3', ref: 'c582a227417ddc55ed7011b3208d37113ce87f09' }
+"0.40.x" => { version: '1.0.3', ref: 'c582a227417ddc55ed7011b3208d37113ce87f09' }

--- a/app/controllers/spree/admin/active_shipping_settings_controller.rb
+++ b/app/controllers/spree/admin/active_shipping_settings_controller.rb
@@ -5,7 +5,7 @@ class Spree::Admin::ActiveShippingSettingsController < Spree::Admin::BaseControl
     @preferences_FedEx = [:fedex_login, :fedex_password, :fedex_account, :fedex_key]
     @preferences_USPS = [:usps_login, :usps_commercial_base, :usps_commercial_plus]
     @preferences_CanadaPost = [:canada_post_login]
-    @preferences_GeneralSettings = [:units, :unit_multiplier, :default_weight, :handling_fee, 
+    @preferences_GeneralSettings = [:units, :unit_multiplier, :default_weight, :handling_fee,
       :max_weight_per_package, :test_mode]
 
     @config = Spree::ActiveShippingConfiguration.new

--- a/app/controllers/spree/admin/product_packages_controller.rb
+++ b/app/controllers/spree/admin/product_packages_controller.rb
@@ -1,12 +1,12 @@
 module Spree
   module Admin
     class ProductPackagesController < ResourceController
-      belongs_to 'spree/product', :find_by => :slug
+      belongs_to 'spree/product', find_by: :slug
       before_filter :load_data
 
       private
         def load_data
-          @product = Product.where(:slug => params[:product_id]).first
+          @product = Product.find_by(slug: params[:product_id])
         end
 
         def permitted_product_package_attributes

--- a/app/controllers/spree/admin/products_controller_decorator.rb
+++ b/app/controllers/spree/admin/products_controller_decorator.rb
@@ -3,10 +3,10 @@ Spree::Admin::ProductsController.class_eval do
     @product = Spree::Product.find_by_slug!(params[:id])
     @packages = @product.product_packages
     @product.product_packages.build
-    
+
     respond_with(@object) do |format|
-    format.html { render :layout => !request.xhr? }
-      format.js { render :layout => false }
+      format.html { render layout: !request.xhr? }
+      format.js { render layout: false }
     end
   end
 end

--- a/app/controllers/spree/checkout_controller_decorator.rb
+++ b/app/controllers/spree/checkout_controller_decorator.rb
@@ -1,7 +1,7 @@
 # handle shipping errors gracefully during checkout
 Spree::CheckoutController.class_eval do
 
-  rescue_from Spree::ShippingError, :with => :handle_shipping_error
+  rescue_from Spree::ShippingError, with: :handle_shipping_error
 
   private
     def handle_shipping_error(e)

--- a/app/controllers/spree/orders_controller_decorator.rb
+++ b/app/controllers/spree/orders_controller_decorator.rb
@@ -1,7 +1,7 @@
 # handle shipping errors gracefully during order update
 Spree::OrdersController.class_eval do
 
-  rescue_from Spree::ShippingError, :with => :handle_shipping_error
+  rescue_from Spree::ShippingError, with: :handle_shipping_error
 
   private
     def handle_shipping_error(e)

--- a/app/models/spree/calculator/shipping/active_shipping/base.rb
+++ b/app/models/spree/calculator/shipping/active_shipping/base.rb
@@ -49,15 +49,15 @@ module Spree
         def timing(line_items)
           order = line_items.first.order
           # TODO: Figure out where stock_location is supposed to come from.
-          origin= ::ActiveShipping::Location.new(:country => stock_location.country.iso,
-                               :city => stock_location.city,
-                               :state => (stock_location.state ? stock_location.state.abbr : stock_location.state_name),
-                               :zip => stock_location.zipcode)
+          origin= ::ActiveShipping::Location.new(country: stock_location.country.iso,
+                               city: stock_location.city,
+                               state: (stock_location.state ? stock_location.state.abbr : stock_location.state_name),
+                               zip: stock_location.zipcode)
           addr = order.ship_address
-          destination = ::ActiveShipping::Location.new(:country => addr.country.iso,
-                                     :state => (addr.state ? addr.state.abbr : addr.state_name),
-                                     :city => addr.city,
-                                     :zip => addr.zipcode)
+          destination = ::ActiveShipping::Location.new(country: addr.country.iso,
+                                     state: (addr.state ? addr.state.abbr : addr.state_name),
+                                     city: addr.city,
+                                     zip: addr.zipcode)
           timings_result = Rails.cache.fetch(cache_key(package)+"-timings") do
             retrieve_timings(origin, destination, packages(order))
           end
@@ -213,22 +213,22 @@ module Spree
           item_specific_packages = convert_package_to_item_packages_array(package)
 
           if max_weight <= 0
-            packages << ::ActiveShipping::Package.new(weights.sum, dimensions, :units => units)
+            packages << ::ActiveShipping::Package.new(weights.sum, dimensions, units: units)
           else
             package_weight = 0
             weights.each do |content_weight|
               if package_weight + content_weight <= max_weight
                 package_weight += content_weight
               else
-                packages << ::ActiveShipping::Package.new(package_weight, dimensions, :units => units)
+                packages << ::ActiveShipping::Package.new(package_weight, dimensions, units: units)
                 package_weight = content_weight
               end
             end
-            packages << ::ActiveShipping::Package.new(package_weight, dimensions, :units => units) if package_weight > 0
+            packages << ::ActiveShipping::Package.new(package_weight, dimensions, units: units) if package_weight > 0
           end
 
           item_specific_packages.each do |package|
-            packages << ::ActiveShipping::Package.new(package.at(0), [package.at(1), package.at(2), package.at(3)], :units => :imperial)
+            packages << ::ActiveShipping::Package.new(package.at(0), [package.at(1), package.at(2), package.at(3)], units: :imperial)
           end
 
           packages
@@ -260,10 +260,10 @@ module Spree
         end
 
         def build_location address
-          ::ActiveShipping::Location.new(:country => address.country.iso,
-                       :state   => fetch_best_state_from_address(address),
-                       :city    => address.city,
-                       :zip     => address.zipcode)
+          ::ActiveShipping::Location.new(country: address.country.iso,
+                       state: fetch_best_state_from_address(address),
+                       city: address.city,
+                       zip: address.zipcode)
         end
 
         def retrieve_rates_from_cache package, origin, destination

--- a/app/models/spree/calculator/shipping/canada_post/base.rb
+++ b/app/models/spree/calculator/shipping/canada_post/base.rb
@@ -6,10 +6,10 @@ module Spree
       class Base < Spree::Calculator::Shipping::ActiveShipping::Base
         def carrier
           canada_post_options = {
-            :login  => Spree::ActiveShipping::Config[:canada_post_login],
-            :french => (I18n.locale.to_sym == :fr)
+            login: Spree::ActiveShipping::Config[:canada_post_login],
+            french: I18n.locale.to_sym.eql?(:fr)
           }
-          ActiveShipping::CanadaPost.new(canada_post_options)
+          ::ActiveShipping::CanadaPost.new(canada_post_options)
         end
       end
     end

--- a/app/models/spree/calculator/shipping/fedex/base.rb
+++ b/app/models/spree/calculator/shipping/fedex/base.rb
@@ -6,14 +6,13 @@ module Spree
       class Base < Spree::Calculator::Shipping::ActiveShipping::Base
         def carrier
           carrier_details = {
-            :key => Spree::ActiveShipping::Config[:fedex_key],
-            :password => Spree::ActiveShipping::Config[:fedex_password],
-            :account => Spree::ActiveShipping::Config[:fedex_account],
-            :login => Spree::ActiveShipping::Config[:fedex_login],
-            :test => Spree::ActiveShipping::Config[:test_mode]
+            key: Spree::ActiveShipping::Config[:fedex_key],
+            password: Spree::ActiveShipping::Config[:fedex_password],
+            account: Spree::ActiveShipping::Config[:fedex_account],
+            login: Spree::ActiveShipping::Config[:fedex_login],
+            test: Spree::ActiveShipping::Config[:test_mode]
           }
-
-          ActiveShipping::FedEx.new(carrier_details)
+          ::ActiveShipping::FedEx.new(carrier_details)
         end
       end
     end

--- a/app/models/spree/calculator/shipping/ups/base.rb
+++ b/app/models/spree/calculator/shipping/ups/base.rb
@@ -6,14 +6,14 @@ module Spree
       class Base < Spree::Calculator::Shipping::ActiveShipping::Base
         def carrier
           carrier_details = {
-            :login => Spree::ActiveShipping::Config[:ups_login],
-            :password => Spree::ActiveShipping::Config[:ups_password],
-            :key => Spree::ActiveShipping::Config[:ups_key],
-            :test => Spree::ActiveShipping::Config[:test_mode]
+            login: Spree::ActiveShipping::Config[:ups_login],
+            password: Spree::ActiveShipping::Config[:ups_password],
+            key: Spree::ActiveShipping::Config[:ups_key],
+            test: Spree::ActiveShipping::Config[:test_mode]
           }
 
           if shipper_number = Spree::ActiveShipping::Config[:shipper_number]
-            carrier_details.merge!(:origin_account => shipper_number)
+            carrier_details.merge!(origin_account: shipper_number)
           end
 
           ::ActiveShipping::UPS.new(carrier_details)

--- a/app/models/spree/calculator/shipping/usps/base.rb
+++ b/app/models/spree/calculator/shipping/usps/base.rb
@@ -4,8 +4,8 @@ module Spree
       class Base < Spree::Calculator::Shipping::ActiveShipping::Base
 
         SERVICE_CODE_PREFIX ||= {
-          :international => 'intl',
-          :domestic      => 'dom'
+          international: 'intl',
+          domestic: 'dom'
         }
 
         def compute_package(package)
@@ -30,8 +30,8 @@ module Spree
 
         def carrier
           carrier_details = {
-            :login => Spree::ActiveShipping::Config[:usps_login],
-            :test => Spree::ActiveShipping::Config[:test_mode]
+            login: Spree::ActiveShipping::Config[:usps_login],
+            test: Spree::ActiveShipping::Config[:test_mode]
           }
 
           ::ActiveShipping::USPS.new(carrier_details)

--- a/app/models/spree/calculator/shipping/usps/express_mail_international.rb
+++ b/app/models/spree/calculator/shipping/usps/express_mail_international.rb
@@ -36,6 +36,7 @@ module Spree
         end
 
         protected
+
         # weight limit in ounces or zero (if there is no limit)
         def max_weight_for_country(country)
           return WEIGHT_LIMITS[country.iso]

--- a/app/models/spree/line_item_decorator.rb
+++ b/app/models/spree/line_item_decorator.rb
@@ -1,4 +1,4 @@
 # Add product packages relation
 Spree::LineItem.class_eval do
-  has_many :product_packages, :through => :product
+  has_many :product_packages, through: :product
 end

--- a/app/models/spree/product_decorator.rb
+++ b/app/models/spree/product_decorator.rb
@@ -1,6 +1,6 @@
 # Add product packages relation
 Spree::Product.class_eval do
-  has_many :product_packages, :dependent => :destroy
+  has_many :product_packages, dependent: :destroy
 
-  accepts_nested_attributes_for :product_packages, :allow_destroy => true, :reject_if => lambda { |pp| pp[:weight].blank? or Integer(pp[:weight]) < 1 }
+  accepts_nested_attributes_for :product_packages, allow_destroy: true, reject_if: lambda { |pp| (pp[:weight].blank? || (Integer(pp[:weight]) < 1)) }
 end

--- a/app/models/spree/product_package.rb
+++ b/app/models/spree/product_package.rb
@@ -3,8 +3,8 @@ module Spree
     belongs_to :product
 
     validates :length, :width, :height, :weight,
-              :numericality => { :only_integer => true,
-                                 :message => Spree.t('validation.must_be_int'),
-                                 :greater_than => 0 }
+              numericality: { only_integer: true,
+                                message: Spree.t('validation.must_be_int'),
+                                greater_than: 0 }
   end
 end

--- a/app/models/spree/stock_location_decorator.rb
+++ b/app/models/spree/stock_location_decorator.rb
@@ -4,7 +4,7 @@ Spree::StockLocation.class_eval do
 
   def state_id_or_state_name_is_present
     if state_id.nil? && state_name.nil?
-        errors.add(:state_name, "can't be blank")
+      errors.add(:state_name, "can't be blank")
     end
   end
 end

--- a/app/views/spree/admin/active_shipping_settings/edit.html.erb
+++ b/app/views/spree/admin/active_shipping_settings/edit.html.erb
@@ -1,10 +1,10 @@
-<%= render :partial => 'spree/admin/shared/sub_menu/configuration' %>
+<%= render partial: 'spree/admin/shared/sub_menu/configuration' %>
 
 <% content_for :page_title do %>
   <%= Spree.t(:active_shipping_settings) %>
 <% end %>
 
-<%= form_tag admin_active_shipping_settings_path, :method => :put  do |form| %>
+<%= form_tag admin_active_shipping_settings_path, method: :put  do |form| %>
   <div id="preferences" data-hook>
     <fieldset class="general no-border-top">
       <div class="row">
@@ -15,7 +15,7 @@
                 type = @config.preference_type(key) %>
                 <div class="field">
                   <%= label_tag(key, Spree.t(key) + ': ') + tag(:br) if type != :boolean %>
-                  <%= preference_field_tag(key, @config[key], :type => type) %>
+                  <%= preference_field_tag(key, @config[key], type: type) %>
                   <%= label_tag(key, Spree.t(key)) + tag(:br) if type == :boolean %>
                 </div>
             <% end %>
@@ -28,7 +28,7 @@
                 type = @config.preference_type(key) %>
                 <div class="field">
                   <%= label_tag(key, Spree.t(key) + ': ') + tag(:br) if type != :boolean %>
-                  <%= preference_field_tag(key, @config[key], :type => type) %>
+                  <%= preference_field_tag(key, @config[key], type: type) %>
                   <%= label_tag(key, Spree.t(key)) + tag(:br) if type == :boolean %>
                 </div>
             <% end %>
@@ -44,7 +44,7 @@
                 type = @config.preference_type(key) %>
                 <div class="field">
                   <%= label_tag(key, Spree.t(key) + ': ') + tag(:br) if type != :boolean %>
-                  <%= preference_field_tag(key, @config[key], :type => type) %>
+                  <%= preference_field_tag(key, @config[key], type: type) %>
                   <%= label_tag(key, Spree.t(key)) + tag(:br) if type == :boolean %>
                 </div>
             <% end %>
@@ -57,7 +57,7 @@
                 type = @config.preference_type(key) %>
                 <div class="field">
                   <%= label_tag(key, Spree.t(key) + ': ') + tag(:br) if type != :boolean %>
-                  <%= preference_field_tag(key, @config[key], :type => type) %>
+                  <%= preference_field_tag(key, @config[key], type: type) %>
                   <%= label_tag(key, Spree.t(key)) + tag(:br) if type == :boolean %>
                 </div>
             <% end %>
@@ -73,7 +73,7 @@
                 type = @config.preference_type(key) %>
                 <div class="field">
                   <%= label_tag(key, Spree.t(key) + ': ') + tag(:br) if type != :boolean %>
-                  <%= preference_field_tag(key, @config[key], :type => type) %>
+                  <%= preference_field_tag(key, @config[key], type: type) %>
                   <%= label_tag(key, Spree.t(key)) + tag(:br) if type == :boolean %>
                 </div>
             <% end %>

--- a/app/views/spree/admin/product_packages/edit.html.erb
+++ b/app/views/spree/admin/product_packages/edit.html.erb
@@ -1,8 +1,8 @@
-<%= form_for [:admin, @product, @product_package], :html => { :multipart => true } do |f| %>
+<%= form_for [:admin, @product, @product_package], html: { multipart: true } do |f| %>
   <fieldset data-hook="edit_product_package">
     <legend align="center"><%= Spree.t(:edit_package) %></legend>
 
-      <%= render :partial => 'form', :locals => { :f => f } %>
+      <%= render partial: 'form', locals: { f: f } %>
 
       <%= render partial: 'spree/admin/shared/edit_resource_links', locals: { collection_url: admin_product_product_packages_url(@product) } %>
   </fieldset>

--- a/app/views/spree/admin/product_packages/index.html.erb
+++ b/app/views/spree/admin/product_packages/index.html.erb
@@ -1,13 +1,13 @@
 <% content_for :page_actions do %>
-  <%= button_link_to Spree.t(:new_package), new_admin_product_product_package_url(@product), { :class => "btn-success", :icon => 'add', :id => 'new_product_package_link' } %>
+  <%= button_link_to Spree.t(:new_package), new_admin_product_product_package_url(@product), { class: "btn-success", icon: 'add', id: 'new_product_package_link' } %>
 <% end %>
 
 <% content_for :head do %>
   <%= javascript_include_tag 'admin/product_packages/index.js' %>
 <% end %>
 
-<%= render :partial => 'spree/admin/shared/sub_menu/product' %>
-<%= render :partial => 'spree/admin/shared/product_tabs', :locals => { :current => 'Product Packages' } %>
+<%= render partial: 'spree/admin/shared/sub_menu/product' %>
+<%= render partial: 'spree/admin/shared/product_tabs', locals: { current: 'Product Packages' } %>
 
 <div id="product_packages" data-hook></div>
 
@@ -34,8 +34,8 @@
           <td><%= package.height %></td>
           <td><%= package.weight %></td>
           <td class="actions actions-2 text-right">
-            <%= link_to_edit(package, :no_text => true) %>
-            <%= link_to_delete(package, :no_text => true) %>
+            <%= link_to_edit(package, no_text: true) %>
+            <%= link_to_delete(package, no_text: true) %>
           </td>
         </tr>
       <% end %>

--- a/app/views/spree/admin/product_packages/new.html.erb
+++ b/app/views/spree/admin/product_packages/new.html.erb
@@ -1,8 +1,8 @@
-<%= form_for [:admin, @product, @product_package], :html => { :multipart => true } do |f| %>
+<%= form_for [:admin, @product, @product_package], html: { multipart: true } do |f| %>
   <fieldset data-hook="new_product_package">
     <legend align="center"><%= Spree.t(:new_package) %></legend>
 
-      <%= render :partial => 'form', :locals => { :f => f } %>
+      <%= render partial: 'form', locals: { f: f } %>
 
       <%= render partial: 'spree/admin/shared/edit_resource_links', locals: { collection_url: admin_product_product_packages_url(@product) } %>
   </fieldset>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,8 +1,8 @@
 Spree::Core::Engine.add_routes do
   namespace :admin do
-    resource :active_shipping_settings, :only => ['show', 'update', 'edit']
+    resource :active_shipping_settings, only: [:show, :update, :edit]
 
-    resources :products, :only => [] do
+    resources :products, only: [] do
       resources :product_packages
     end
   end

--- a/lib/spree/active_shipping/canada_post_override.rb
+++ b/lib/spree/active_shipping/canada_post_override.rb
@@ -16,30 +16,29 @@ module Spree
           # <!--   - weight      (mandatory)      -->
           # <!--   - description (mandatory)      -->
           # <!--   - ready to ship (optional)     -->
-          
+
           def build_line_items(line_items)
             xml_builder = Nokogiri::XML::Builder.new do |xml|
               xml.lineItems do
 
                 line_items.each do |line_item|
                   xml.item do
-                    xml.quantity(1) 
+                    xml.quantity(1)
                     xml.weight(line_item.kilograms)
                     xml.length(line_item.cm(:length).to_s)
                     xml.width(line_item.cm(:width).to_s)
                     xml.height(line_item.cm(:height).to_s)
                     xml.description(line_item.options[:description] || ' ')
                     xml.readyToShip if line_item.options[:ready_to_ship] # SPREE OVERRIDE
-                    
+
                     # By setting the 'readyToShip' tag to true, Sell Online will not pack this item in the boxes defined in the merchant profile.
                   end
                 end
               end
             end
-            
+
             xml_builder.to_xml
           end
-
         end
 
       end

--- a/lib/spree/active_shipping/ups_override.rb
+++ b/lib/spree/active_shipping/ups_override.rb
@@ -64,7 +64,7 @@ module Spree
             packages = Array(packages)
 
             xml_builder = Nokogiri::XML::Builder.new do |xml|
-              xml.TimeInTransitRequest do 
+              xml.TimeInTransitRequest do
                 xml.Request do
                   xml.TransactionReference do
                     xml.CustomerContext('Time in Transit')
@@ -181,14 +181,14 @@ module Spree
 
                 ::ActiveShipping::RateEstimate.new(origin, destination, ::ActiveShipping::UPS.name,
                     service_name_for(origin, service_code),
-                    :total_price => total_price,
-                    :currency => currency,
-                    :service_code => service_code,
-                    :packages => packages
-                    )
+                    total_price: total_price,
+                    currency: currency,
+                    service_code: service_code,
+                    packages: packages
+                  )
               end
             end
-            ::ActiveShipping::RateResponse.new(success, message, Hash.from_xml(response).values.first, :rates => rate_estimates, :xml => response, :request => last_request)
+            ::ActiveShipping::RateResponse.new(success, message, Hash.from_xml(response).values.first, rates: rate_estimates, xml: response, request: last_request)
           end
 
 
@@ -229,18 +229,23 @@ module Spree
               rate_estimates = {}
 
               xml.root.css('TransitResponse ServiceSummary').each do |service_summary|
-                service_code    = service_summary.at('Service/Code').text
+                service_code = service_summary.at('Service/Code').text
                 service_code_2 = time_code_mapping[service_code]
-                service_desc    = service_summary.at('Service/Description').text
+                service_desc = service_summary.at('Service/Description').text
                 guaranteed_code = service_summary.at('Guaranteed/Code').text
                 business_transit_days = service_summary.at('EstimatedArrival/BusinessTransitDays').text
                 date = service_summary.at('EstimatedArrival/Date').text
-                rate_estimates[service_name_for(origin, service_code_2)] = {:service_code => service_code, :service_code_2 => service_code_2, :service_desc => service_desc,
-                    :guaranteed_code => guaranteed_code, :business_transit_days => business_transit_days,
-                    :date => date}
+                rate_estimates[service_name_for(origin, service_code_2)] = {
+                  service_code: service_code,
+                  service_code_2: service_code_2,
+                  service_desc: service_desc,
+                  guaranteed_code: guaranteed_code,
+                  business_transit_days: business_transit_days,
+                  date: date
+                }
               end
             end
-            return rate_estimates
+            rate_estimates
           end
 
         end

--- a/lib/spree/active_shipping_configuration.rb
+++ b/lib/spree/active_shipping_configuration.rb
@@ -1,26 +1,26 @@
 class Spree::ActiveShippingConfiguration < Spree::Preferences::Configuration
 
-  preference :ups_login, :string, :default => "aunt_judy"
-  preference :ups_password, :string, :default => "secret"
-  preference :ups_key, :string, :default => "developer_key"
-  preference :shipper_number, :string, :default => nil
+  preference :ups_login, :string, default: "aunt_judy"
+  preference :ups_password, :string, default: "secret"
+  preference :ups_key, :string, default: "developer_key"
+  preference :shipper_number, :string, default: nil
 
-  preference :fedex_login, :string, :default => "meter_no"
-  preference :fedex_password, :string, :default => "special_sha1_looking_thing_sent_via_email"
-  preference :fedex_account, :string, :default => "account_no"
-  preference :fedex_key, :string, :default => "authorization_key"
+  preference :fedex_login, :string, default: "meter_no"
+  preference :fedex_password, :string, default: "special_sha1_looking_thing_sent_via_email"
+  preference :fedex_account, :string, default: "account_no"
+  preference :fedex_key, :string, default: "authorization_key"
 
-  preference :usps_login, :string, :default => "aunt_judy"
-  preference :usps_commercial_base, :boolean, :default => false
-  preference :usps_commercial_plus, :boolean, :default => false
+  preference :usps_login, :string, default: "aunt_judy"
+  preference :usps_commercial_base, :boolean, default: false
+  preference :usps_commercial_plus, :boolean, default: false
 
-  preference :canada_post_login, :string, :default => "canada_post_login"
+  preference :canada_post_login, :string, default: "canada_post_login"
 
-  preference :units, :string, :default => "imperial"
-  preference :unit_multiplier, :decimal, :default => 16 # 16 oz./lb - assumes variant weights are in lbs
-  preference :default_weight, :integer, :default => 0 # 16 oz./lb - assumes variant weights are in lbs
+  preference :units, :string, default: "imperial"
+  preference :unit_multiplier, :decimal, default: 16 # 16 oz./lb - assumes variant weights are in lbs
+  preference :default_weight, :integer, default: 0 # 16 oz./lb - assumes variant weights are in lbs
   preference :handling_fee, :integer
-  preference :max_weight_per_package, :integer, :default => 0 # 0 means no limit
+  preference :max_weight_per_package, :integer, default: 0 # 0 means no limit
 
-  preference :test_mode, :boolean, :default => false
+  preference :test_mode, :boolean, default: false
 end

--- a/lib/spree_active_shipping/engine.rb
+++ b/lib/spree_active_shipping/engine.rb
@@ -40,7 +40,7 @@ module SpreeActiveShippingExtension
     end
 
         # sets the manifests / assets to be precompiled, even when initialize_on_precompile is false
-    initializer "spree.assets.precompile", :group => :all do |app|
+    initializer "spree.assets.precompile", group: :all do |app|
       app.config.assets.precompile += %w[
         admin/product_packages/new.js
         admin/product_packages/edit.js

--- a/spec/factories/product_package_factory.rb
+++ b/spec/factories/product_package_factory.rb
@@ -5,5 +5,5 @@ FactoryGirl.define do
     height { SecureRandom.random_number(19) + 1 }
     weight { SecureRandom.random_number(19) + 1 }
     product
-  end 
+  end
 end

--- a/spec/support/rspec-activemodel-mocks_patch.rb
+++ b/spec/support/rspec-activemodel-mocks_patch.rb
@@ -1,8 +1,0 @@
-# Manually applied the patch from https://github.com/jdelStrother/rspec-activemodel-mocks/commit/1211c347c5a574739616ccadf4b3b54686f9051f
-if Gem.loaded_specs['rspec-activemodel-mocks'].version.to_s != "1.0.0"
-  raise "RSpec-ActiveModel-Mocks version has changed, please check if the behaviour has already been fixed: https://github.com/rspec/rspec-activemodel-mocks/pull/10
-If so, this patch might be obsolete-"
-end
-RSpec::ActiveModel::Mocks::Mocks::ActiveRecordInstanceMethods.class_eval do
-  alias_method :_read_attribute, :[]
-end

--- a/spree_active_shipping.gemspec
+++ b/spree_active_shipping.gemspec
@@ -21,6 +21,7 @@ Gem::Specification.new do |s|
   s.add_dependency('active_shipping', '~> 1.4.2')
   s.add_development_dependency 'pry'
   s.add_development_dependency 'webmock'
-  s.add_development_dependency 'sass-rails', '~> 4.0.2'
+  s.add_development_dependency 'sass-rails', '~> 5.0'
+  s.add_development_dependency 'coffee-rails', '~> 4.1'
   s.add_development_dependency 'simplecov'
 end


### PR DESCRIPTION
1. Bump rspec-activemodel-mocks, rspec-rails and sass-rails versions.
2. Remove patch of rspec-activemodel-mocks since its fix is already merged.
3. Update ruby syntax.

Above changes are made against the master branch.