### PR TITLE
Set spree_core to >= 3.1.0 and < 4.0 versions

### DIFF
--- a/spree_active_shipping.gemspec
+++ b/spree_active_shipping.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
   s.require_paths = ["lib"]
 
-  s.add_dependency('spree_core', '~> 3.2.0.alpha')
+  s.add_dependency('spree_core', '>= 3.1.0', '< 4.0')
   s.add_dependency('active_shipping', '~> 1.4.2')
   s.add_development_dependency 'pry'
   s.add_development_dependency 'webmock'


### PR DESCRIPTION
This PR changes the version of `spree_core` in gemspec to point at `>= 3.1.0` and `< 4.0`.