### PR TITLE
Added some Australia Post options

### DIFF
--- a/app/controllers/spree/admin/active_shipping_settings_controller.rb
+++ b/app/controllers/spree/admin/active_shipping_settings_controller.rb
@@ -5,6 +5,7 @@ class Spree::Admin::ActiveShippingSettingsController < Spree::Admin::BaseControl
     @preferences_FedEx = [:fedex_login, :fedex_password, :fedex_account, :fedex_key]
     @preferences_USPS = [:usps_login, :usps_commercial_base, :usps_commercial_plus]
     @preferences_CanadaPost = [:canada_post_login]
+    @preferences_AustraliaPost = [:australia_post_login]
     @preferences_GeneralSettings = [:units, :unit_multiplier, :default_weight, :handling_fee,
       :max_weight_per_package, :test_mode]
 

--- a/app/models/spree/calculator/shipping/australia_post/base.rb
+++ b/app/models/spree/calculator/shipping/australia_post/base.rb
@@ -1,0 +1,16 @@
+require_dependency 'spree/calculator'
+
+module Spree
+  module Calculator::Shipping
+    module AustraliaPost
+      class Base < Spree::Calculator::Shipping::ActiveShipping::Base
+        def carrier
+          australia_post_options = {
+            api_key: Spree::ActiveShipping::Config[:australia_post_login],
+          }
+          ::ActiveShipping::AustraliaPost.new(australia_post_options)
+        end
+      end
+    end
+  end
+end

--- a/app/models/spree/calculator/shipping/australia_post/courier_post.rb
+++ b/app/models/spree/calculator/shipping/australia_post/courier_post.rb
@@ -1,0 +1,11 @@
+module Spree
+  module Calculator::Shipping
+    module AustraliaPost
+      class CourierPost < Spree::Calculator::Shipping::AustraliaPost::Base
+        def self.description
+          "Courier Post"
+        end
+      end
+    end
+  end
+end

--- a/app/models/spree/calculator/shipping/australia_post/parcel_post.rb
+++ b/app/models/spree/calculator/shipping/australia_post/parcel_post.rb
@@ -1,0 +1,11 @@
+module Spree
+  module Calculator::Shipping
+    module AustraliaPost
+      class ParcelPost < Spree::Calculator::Shipping::AustraliaPost::Base
+        def self.description
+          "Parcel Post"
+        end
+      end
+    end
+  end
+end

--- a/app/models/spree/calculator/shipping/australia_post/priority_letters.rb
+++ b/app/models/spree/calculator/shipping/australia_post/priority_letters.rb
@@ -1,0 +1,11 @@
+module Spree
+  module Calculator::Shipping
+    module AustraliaPost
+      class PriorityLetters < Spree::Calculator::Shipping::AustraliaPost::Base
+        def self.description
+          "Priority Letters"
+        end
+      end
+    end
+  end
+end

--- a/app/views/spree/admin/active_shipping_settings/edit.html.erb
+++ b/app/views/spree/admin/active_shipping_settings/edit.html.erb
@@ -63,6 +63,19 @@
             <% end %>
           </fieldset>
         </div>
+        <div class="col-md-6">
+          <fieldset class="currency no-border-bottom">
+            <legend align="center"><%= Spree.t(:australia_post_settings)%></legend>
+            <% @preferences_AustraliaPost.each do |key|
+              type = @config.preference_type(key) %>
+                <div class="field">
+                  <%= label_tag(key, Spree.t(key) + ': ') + tag(:br) if type != :boolean %>
+                  <%= preference_field_tag(key, @config[key], type: type) %>
+                  <%= label_tag(key, Spree.t(key)) + tag(:br) if type == :boolean %>
+                </div>
+            <% end %>
+          </fieldset>
+        </div>
       </div>
 
       <div class="row">

--- a/lib/spree/active_shipping_configuration.rb
+++ b/lib/spree/active_shipping_configuration.rb
@@ -16,6 +16,8 @@ class Spree::ActiveShippingConfiguration < Spree::Preferences::Configuration
 
   preference :canada_post_login, :string, default: "canada_post_login"
 
+  preference :australia_post_login, :string, default: "australia_post_api_key"
+
   preference :units, :string, default: "imperial"
   preference :unit_multiplier, :decimal, default: 16 # 16 oz./lb - assumes variant weights are in lbs
   preference :default_weight, :integer, default: 0 # 16 oz./lb - assumes variant weights are in lbs


### PR DESCRIPTION
Added support for some Australia Post shipping options. Only issue is the Australia Post shipping options are not prefixed with "Australia Post" so they show up in the spree admin page as just "Parcel Post". Not really sure what can be done about this but otherwise it should all be working.