### PR TITLE
Update active shipping version

### DIFF
--- a/spree_active_shipping.gemspec
+++ b/spree_active_shipping.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
 
   s.add_dependency 'spree_core', '>= 3.1.0', '< 4.0'
-  s.add_dependency 'active_shipping', '~> 1.4'
+  s.add_dependency 'active_shipping', '>= 1.4'
   s.add_dependency 'spree_extension'
 
   s.add_development_dependency 'pry'


### PR DESCRIPTION
This bumps the ```active_shipping``` to version greater than 1.4