### PR TITLE
Fix: namespace local to Spree

### DIFF
--- a/app/overrides/spree/admin/shared/sub_menu/_configuration/add_active_shipping_settings_tab.html.erb.deface
+++ b/app/overrides/spree/admin/shared/sub_menu/_configuration/add_active_shipping_settings_tab.html.erb.deface
@@ -1,3 +1,3 @@
 <!-- insert_bottom "[data-hook='admin_configurations_sidebar_menu'], #admin_configurations_sidebar_menu[data-hook]" -->
 
-<%= configurations_sidebar_menu_item t(:active_shipping_settings), edit_admin_active_shipping_settings_path %>
+<%= configurations_sidebar_menu_item Spree.t(:active_shipping_settings), edit_admin_active_shipping_settings_path %>

--- a/spree_active_shipping.gemspec
+++ b/spree_active_shipping.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'sass-rails'
   s.add_development_dependency 'coffee-rails'
   s.add_development_dependency 'simplecov'
-  s.add_development_dependency 'factory_bot_rails'
+  s.add_development_dependency 'factory_bot_rails', '~> 4.11'
   s.add_development_dependency 'ffaker'
   s.add_development_dependency 'rspec-rails'
   s.add_development_dependency 'rspec-activemodel-mocks'


### PR DESCRIPTION
Error popped up when bumping to Spree 3.6.