### PR TITLE
Updates travis:  Bump rvm & gemfiles in sync with other spree-contrib gems 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,9 +8,9 @@ env:
   - DB=mysql
 
 gemfile:
-  - gemfiles/spree_3_1.gemfile
   - gemfiles/spree_3_2.gemfile
-  - gemfiles/spree_3_3.gemfile
+  - gemfiles/spree_3_5.gemfile
+  - gemfiles/spree_3_7.gemfile
   - gemfiles/spree_master.gemfile
 
 script:
@@ -18,9 +18,9 @@ script:
   - bundle exec rake spec
 
 rvm:
-  - 2.4.4
-  - 2.3.1
-  - 2.2.7
+  - 2.5.3
+  - 2.4.5
+  - 2.3.8
 
 matrix:
     allow_failures:

--- a/app/overrides/spree/admin/shared/sub_menu/_configuration/add_active_shipping_settings_tab.html.erb.deface
+++ b/app/overrides/spree/admin/shared/sub_menu/_configuration/add_active_shipping_settings_tab.html.erb.deface
@@ -1,3 +1,3 @@
 <!-- insert_bottom "[data-hook='admin_configurations_sidebar_menu'], #admin_configurations_sidebar_menu[data-hook]" -->
 
-<%= configurations_sidebar_menu_item t(:active_shipping_settings), edit_admin_active_shipping_settings_path %>
+<%= configurations_sidebar_menu_item Spree.t(:active_shipping_settings), edit_admin_active_shipping_settings_path %>


### PR DESCRIPTION
Drops support for Spree 3.1 & Ruby 2.2.x